### PR TITLE
Fix public API visibility and decodable id

### DIFF
--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct LBLog: Codable, Identifiable {
-    public let id: String = UUID().uuidString
+    public let id: String
     public let level: LBLogLevel
     public let message: String?
     public let extraMessages: [LBExtraMessage]?
@@ -17,17 +17,50 @@ public struct LBLog: Codable, Identifiable {
     public let createdAt: Double
     public let location: LBLocation
     public let source: LBSource
+
+    public init(
+        id: String = UUID().uuidString,
+        level: LBLogLevel,
+        message: String? = nil,
+        extraMessages: [LBExtraMessage]? = nil,
+        additionalInfo: [String: String]? = nil,
+        error: LBError? = nil,
+        createdAt: Double,
+        location: LBLocation,
+        source: LBSource
+    ) {
+        self.id = id
+        self.level = level
+        self.message = message
+        self.extraMessages = extraMessages
+        self.additionalInfo = additionalInfo
+        self.error = error
+        self.createdAt = createdAt
+        self.location = location
+        self.source = source
+    }
 }
 
 public struct LBSource: Codable {
     public let subsystem: String
     public let category: String
+
+    public init(subsystem: String, category: String) {
+        self.subsystem = subsystem
+        self.category = category
+    }
 }
 
 public struct LBLocation: Codable {
     public let file: String
     public let function: String
     public let line: Int
+
+    public init(file: String, function: String, line: Int) {
+        self.file = file
+        self.function = function
+        self.line = line
+    }
 }
 
 public struct LBError: Codable {
@@ -35,11 +68,18 @@ public struct LBError: Codable {
     public let code: Int
     public let localizedDescription: String
     public let userInfo: [String: String]?
+
+    public init(domain: String, code: Int, localizedDescription: String, userInfo: [String: String]? = nil) {
+        self.domain = domain
+        self.code = code
+        self.localizedDescription = localizedDescription
+        self.userInfo = userInfo
+    }
 }
 
 public struct LBExtraMessage: Codable, Hashable {
-    let title: String
-    let message: String
+    public let title: String
+    public let message: String
 
     public init(title: String, message: String) {
         self.title = title

--- a/Sources/LogBird/LBLogLevel.swift
+++ b/Sources/LogBird/LBLogLevel.swift
@@ -11,7 +11,7 @@ import OSLog
 public enum LBLogLevel: String, Codable, CaseIterable {
     case debug, info, warning, error, critical
     
-    var osLogType: OSLogType {
+    public var osLogType: OSLogType {
         switch self {
         case .debug: return .debug
         case .info: return .info


### PR DESCRIPTION
## Changes

Makes LogBird's public model API visible and constructible. All changes are **additive (non-breaking API)** ✅.

### `LBExtraMessage.title` and `.message` → public
- `Sources/LogBird/LBLog.swift`
- `let title` / `let message` → `public let`. The initializer was already public, but the properties were internal: external consumers could construct the struct but couldn't read its fields.

### `public init` for `LBLog`, `LBSource`, `LBLocation`, `LBError`
- `Sources/LogBird/LBLog.swift`
- The synthesized init was internal, so consumers couldn't construct these types from outside the module (e.g. for tests or to set up a custom `LBSource`).

### `LBLogLevel.osLogType` → public
- `Sources/LogBird/LBLogLevel.swift`
- `var osLogType` → `public var osLogType` (`emoji` was already public). Prevents consumers from having to duplicate the `OSLogType` mapping switch.

### `LBLog.id` decodable
- `Sources/LogBird/LBLog.swift`
- `public let id: String = UUID().uuidString` → `public let id: String` + default in `public init(id: String = UUID().uuidString, ...)`.
- Silences the compiler warning (`immutable property will not be decoded...`) and lets the `id` survive Codable round-trips.

## Verification

- `swift build` ✅ no warnings
- `swift build -Xswiftc -strict-concurrency=complete` ✅
- `swift test` ✅