### PR TITLE
Rework the logs view with search, filtering, export and modern SwiftUI

### DIFF
--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -61,6 +61,11 @@ public struct LBLocation: Codable {
         self.function = function
         self.line = line
     }
+
+    /// The file name component of `file`, without the module path that `#fileID` includes.
+    public var fileName: String {
+        file.split(separator: "/").last.map(String.init) ?? file
+    }
 }
 
 public struct LBError: Codable {

--- a/Sources/LogBird/LBLogLevel.swift
+++ b/Sources/LogBird/LBLogLevel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OSLog
+import SwiftUI
 
 public enum LBLogLevel: String, Codable, CaseIterable {
     case debug, info, warning, error, critical
@@ -28,6 +29,26 @@ public enum LBLogLevel: String, Codable, CaseIterable {
         case .warning: return "⚠️"
         case .error: return "❌"
         case .critical: return "🚨"
+        }
+    }
+
+    public var color: Color {
+        switch self {
+        case .debug: return .secondary
+        case .info: return .blue
+        case .warning: return .yellow
+        case .error: return .orange
+        case .critical: return .red
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .debug: return "ant"
+        case .info: return "info.circle"
+        case .warning: return "exclamationmark.triangle"
+        case .error: return "xmark.octagon"
+        case .critical: return "flame"
         }
     }
 }

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -193,7 +193,7 @@ final class LBManager: @unchecked Sendable {
         logMessage = "\(logMessage)\(source)"
         
         // Location
-        let file: String = "File: \(log.location.file)\n"
+        let file: String = "File: \(log.location.fileName)\n"
         let function: String = "Function: \(log.location.function)\n"
         let line: String = "Line: \(log.location.line)\n"
         let location: String = "Location:\n\(spacing)\(file)\(spacing)\(function)\(spacing)\(line)"

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -19,7 +19,8 @@ enum LBLogExport {
     static let fileName = "logbird-logs.json"
 
     static func writeTemporaryFile(data: Data) -> URL? {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logbird-logs-\(UUID().uuidString).json")
         do {
             try data.write(to: url, options: .atomic)
             return url

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -1,0 +1,55 @@
+//
+//  LBLogExport.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 27/07/2026.
+//
+
+import Foundation
+#if os(iOS)
+import SwiftUI
+import UIKit
+#elseif os(macOS)
+import AppKit
+import UniformTypeIdentifiers
+#endif
+
+enum LBLogExport {
+
+    static let fileName = "logbird-logs.json"
+
+    static func writeTemporaryFile(data: Data) -> URL? {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        do {
+            try data.write(to: url, options: .atomic)
+            return url
+        } catch {
+            return nil
+        }
+    }
+
+    #if os(macOS)
+    @MainActor
+    static func presentSavePanel(data: Data) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = fileName
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            try? data.write(to: url)
+        }
+    }
+    #endif
+}
+
+#if os(iOS)
+struct LBActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+#endif

--- a/Sources/LogBird/LogView/LBLogRowView.swift
+++ b/Sources/LogBird/LogView/LBLogRowView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct LogRowView: View {
+public struct LBLogRowView: View {
     public let log: LBLog
 
     public init(log: LBLog) {
@@ -44,12 +44,20 @@ public struct LogRowView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: Color.black.opacity(0.05), radius: 1, x: 0, y: 1)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(log.level.rawValue.capitalized) log entry")
-        .accessibilityHint("Shows the message, location and source details")
+        .accessibilityLabel(rowAccessibilityLabel)
+        .accessibilityHint("Shows the location and source details")
     }
 }
 
-private extension LogRowView {
+private extension LBLogRowView {
+    var rowAccessibilityLabel: String {
+        var label = "\(log.level.rawValue.capitalized) log entry"
+        if let message = log.message, !message.isEmpty {
+            label += ": \(message)"
+        }
+        return label
+    }
+
     @ViewBuilder
     func Header(createdAt: String, level: LBLogLevel) -> some View {
         HStack {
@@ -145,11 +153,11 @@ private extension LogRowView {
 }
 
 #Preview("Light") {
-    LogRowView(log: .previewSample)
+    LBLogRowView(log: .previewSample)
 }
 
 #Preview("Dark") {
-    LogRowView(log: .previewSample)
+    LBLogRowView(log: .previewSample)
         .preferredColorScheme(.dark)
 }
 

--- a/Sources/LogBird/LogView/LBLogRowView.swift
+++ b/Sources/LogBird/LogView/LBLogRowView.swift
@@ -7,53 +7,45 @@
 
 import SwiftUI
 
-struct LogRowView: View {
-    let log: LBLog
-    
-    var body: some View {
+public struct LogRowView: View {
+    public let log: LBLog
+
+    public init(log: LBLog) {
+        self.log = log
+    }
+
+    public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             let date = LBManager.dateFormatter.string(from: Date(timeIntervalSince1970: log.createdAt))
             Header(createdAt: date, level: log.level)
-            
+
             if let message = log.message, !message.isEmpty {
                 Message(message)
             }
-            
+
             if let extraMessages = log.extraMessages, !extraMessages.isEmpty {
                 ExtraMessages(extraMessages)
             }
-            
+
             if let error = log.error {
                 LogError(error)
             }
-            
+
             if let additionalInfo = log.additionalInfo, !additionalInfo.isEmpty {
                 AdditionalInfo(additionalInfo)
             }
-            
+
             Location(log.location)
-            
+
             Source(log.source)
         }
         .padding()
-        .background(backgroundColor(for: log.level))
-        .cornerRadius(8)
+        .background(log.level.color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: Color.black.opacity(0.05), radius: 1, x: 0, y: 1)
-    }
-    
-    private func backgroundColor(for level: LBLogLevel) -> Color {
-        switch level {
-        case .debug:
-            return Color.gray.opacity(0.1)
-        case .info:
-            return Color.blue.opacity(0.1)
-        case .warning:
-            return Color.yellow.opacity(0.1)
-        case .error:
-            return Color.orange.opacity(0.1)
-        case .critical:
-            return Color.red.opacity(0.1)
-        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(log.level.rawValue.capitalized) log entry")
+        .accessibilityHint("Shows the message, location and source details")
     }
 }
 
@@ -69,26 +61,26 @@ private extension LogRowView {
                 .font(.title2)
         }
     }
-    
+
     @ViewBuilder
     func Message(_ message: String) -> some View {
-        SectionView(title: "Message") {
+        LogSection(title: "Message") {
             Text(message)
         }
     }
-    
+
     @ViewBuilder
     func ExtraMessages(_ extraMessages: [LBExtraMessage]) -> some View {
         ForEach(extraMessages, id: \.self) { value in
-            SectionView(title: value.title) {
+            LogSection(title: value.title) {
                 Text(value.message)
             }
         }
     }
-    
+
     @ViewBuilder
     func AdditionalInfo(_ additionalInfo: [String: String]) -> some View {
-        SectionView(title: "Additional Info") {
+        LogSection(title: "Additional Info") {
             ForEach(additionalInfo.keys.sorted(), id: \.self) { key in
                 if let value = additionalInfo[key] {
                     InfoRow(label: "\(key):", value: value)
@@ -96,14 +88,14 @@ private extension LogRowView {
             }
         }
     }
-    
+
     @ViewBuilder
     func LogError(_ error: LBError) -> some View {
-        SectionView(title: "Error") {
+        LogSection(title: "Error") {
             InfoRow(label: "Domain:", value: error.domain)
-            
+
             InfoRow(label: "Code:", value: "\(error.code)")
-            
+
             if let userInfo = error.userInfo {
                 ForEach(userInfo.keys.sorted(), id: \.self) { key in
                     if let value = userInfo[key] {
@@ -113,26 +105,26 @@ private extension LogRowView {
             }
         }
     }
-    
+
     @ViewBuilder
     func Location(_ location: LBLocation) -> some View {
-        SectionView(title: "Location") {
-            InfoRow(label: "File:", value: location.file)
+        LogSection(title: "Location") {
+            InfoRow(label: "File:", value: location.fileName)
             InfoRow(label: "Function:", value: location.function)
             InfoRow(label: "Line:", value: "\(location.line)")
         }
     }
-    
+
     @ViewBuilder
     func Source(_ source: LBSource) -> some View {
-        SectionView(title: "Source") {
+        LogSection(title: "Source") {
             InfoRow(label: "Subsystem:", value: source.subsystem)
             InfoRow(label: "Category:", value: source.category)
         }
     }
-    
+
     @ViewBuilder
-    func SectionView(title: String, @ViewBuilder content: () -> some View) -> some View {
+    func LogSection(title: String, @ViewBuilder content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text("\(title):")
                 .font(.subheadline)
@@ -141,7 +133,7 @@ private extension LogRowView {
                 .foregroundColor(.secondary)
         }
     }
-    
+
     @ViewBuilder
     func InfoRow(label: String, value: String) -> some View {
         HStack {
@@ -149,5 +141,27 @@ private extension LogRowView {
                 .bold()
             Text(value)
         }
+    }
+}
+
+#Preview("Light") {
+    LogRowView(log: .previewSample)
+}
+
+#Preview("Dark") {
+    LogRowView(log: .previewSample)
+        .preferredColorScheme(.dark)
+}
+
+private extension LBLog {
+    static var previewSample: LBLog {
+        LBLog(
+            level: .info,
+            message: "Network request finished",
+            additionalInfo: ["statusCode": "200"],
+            createdAt: Date().timeIntervalSince1970,
+            location: LBLocation(file: "LogBird/LBManager.swift", function: "log(_:)", line: 42),
+            source: LBSource(subsystem: "com.logbird.preview", category: "network")
+        )
     }
 }

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -39,7 +39,7 @@ public struct LBLogsView: View {
     @ViewBuilder
     private var content: some View {
         List(viewModel.filteredLogs) { log in
-            LogRowView(log: log)
+            LBLogRowView(log: log)
         }
         .listStyle(.plain)
         .accessibilityLabel("Logs list")

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -7,26 +7,112 @@
 
 import SwiftUI
 
+@MainActor
 public struct LBLogsView: View {
-    
+
     @StateObject private var viewModel: LogsViewModel
-    
+
+    #if os(iOS)
+    @State private var exportFile: ExportFile?
+    #endif
+
+    /// Creates a logs view backed by the given `LogBird` instance.
+    ///
+    /// The instance is captured when the view is first created. Passing a
+    /// different instance later does not replace the underlying view model.
     public init(logBird: LogBird = LogBird.shared) {
         _viewModel = StateObject(wrappedValue: LogsViewModel(logBird: logBird))
     }
-    
+
     public var body: some View {
-        NavigationView {
-            VStack {
-                List(viewModel.logs) { log in
-                    LogRowView(log: log)
-                }
-                .listStyle(PlainListStyle())
-                .onAppear {
-                    viewModel.startLogging()
-                }
+        if #available(iOS 16.0, macOS 13.0, *) {
+            NavigationStack {
+                content
             }
-            .navigationTitle("Logs")
+        } else {
+            NavigationView {
+                content
+            }
         }
     }
+
+    @ViewBuilder
+    private var content: some View {
+        List(viewModel.filteredLogs) { log in
+            LogRowView(log: log)
+        }
+        .listStyle(.plain)
+        .accessibilityLabel("Logs list")
+        .accessibilityHint("Displays the recorded log entries")
+        .searchable(text: $viewModel.searchText, prompt: "Search logs")
+        .navigationTitle("Logs")
+        .toolbar {
+            toolbarContent
+        }
+        #if os(iOS)
+        .sheet(item: $exportFile) { file in
+            LBActivityView(activityItems: [file.url])
+        }
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Menu {
+                Picker("Level", selection: $viewModel.levelFilter) {
+                    Text("All levels").tag(LBLogLevel?.none)
+                    ForEach(LBLogLevel.allCases, id: \.self) { level in
+                        Label(level.rawValue.capitalized, systemImage: level.symbolName)
+                            .tag(LBLogLevel?.some(level))
+                    }
+                }
+
+                Divider()
+
+                Button {
+                    exportLogs()
+                } label: {
+                    Label("Export Logs", systemImage: "square.and.arrow.up")
+                }
+
+                Button(role: .destructive) {
+                    viewModel.clearLogs()
+                } label: {
+                    Label("Clear Logs", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .accessibilityLabel("Log options")
+            .accessibilityHint("Filters, exports or clears the logs")
+        }
+    }
+
+    private func exportLogs() {
+        guard let data = viewModel.exportData() else { return }
+        #if os(iOS)
+        if let url = LBLogExport.writeTemporaryFile(data: data) {
+            exportFile = ExportFile(url: url)
+        }
+        #elseif os(macOS)
+        LBLogExport.presentSavePanel(data: data)
+        #endif
+    }
+}
+
+#if os(iOS)
+private struct ExportFile: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+#endif
+
+#Preview("Light") {
+    LBLogsView()
+}
+
+#Preview("Dark") {
+    LBLogsView()
+        .preferredColorScheme(.dark)
 }

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -16,7 +16,7 @@ final class LogsViewModel: ObservableObject {
     @Published var levelFilter: LBLogLevel?
 
     private let logBird: LogBird
-    private var loggingTask: Task<Void, Never>?
+    private var logsCancellable: AnyCancellable?
 
     init(logBird: LogBird = LogBird.shared) {
         self.logBird = logBird
@@ -40,11 +40,14 @@ final class LogsViewModel: ObservableObject {
     }
 
     private func subscribeToLogs() {
-        loggingTask = Task { [weak self, logBird] in
-            for await newLogs in logBird.logsPublisher.values {
-                self?.logs = newLogs
+        logsCancellable = logBird.logsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newLogs in
+                // Delivery is on the main queue, so the main actor hop is guaranteed.
+                MainActor.assumeIsolated {
+                    self?.logs = newLogs
+                }
             }
-        }
     }
 
     private func matchesLevelFilter(_ log: LBLog) -> Bool {
@@ -70,9 +73,5 @@ final class LogsViewModel: ObservableObject {
         }
 
         return log.location.file.localizedCaseInsensitiveContains(query)
-    }
-
-    deinit {
-        loggingTask?.cancel()
     }
 }

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -1,6 +1,6 @@
 //
 //  LogsViewModel.swift
-//  LogBirdExample
+//  LogBird
 //
 //  Created by Javier Manzo on 16/11/2024.
 //
@@ -8,28 +8,71 @@
 import Foundation
 import Combine
 
-class LogsViewModel: ObservableObject {
-    
+@MainActor
+final class LogsViewModel: ObservableObject {
+
     @Published var logs: [LBLog] = []
-    
-    private var subscribers = Set<AnyCancellable>()
+    @Published var searchText: String = ""
+    @Published var levelFilter: LBLogLevel?
+
     private let logBird: LogBird
-    private var timer: AnyCancellable?
-    
+    private var loggingTask: Task<Void, Never>?
+
     init(logBird: LogBird = LogBird.shared) {
         self.logBird = logBird
+        subscribeToLogs()
     }
-    
-    func startLogging() {
-        logBird.logsPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] newLogs in
+
+    var filteredLogs: [LBLog] {
+        logs.filter { log in
+            matchesLevelFilter(log) && matchesSearchText(log)
+        }
+    }
+
+    func clearLogs() {
+        logBird.clearLogs()
+    }
+
+    func exportData() -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try? encoder.encode(filteredLogs)
+    }
+
+    private func subscribeToLogs() {
+        loggingTask = Task { [weak self, logBird] in
+            for await newLogs in logBird.logsPublisher.values {
                 self?.logs = newLogs
             }
-            .store(in: &subscribers)
+        }
     }
-    
+
+    private func matchesLevelFilter(_ log: LBLog) -> Bool {
+        guard let levelFilter else { return true }
+        return log.level == levelFilter
+    }
+
+    private func matchesSearchText(_ log: LBLog) -> Bool {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return true }
+
+        if let message = log.message, message.localizedCaseInsensitiveContains(query) {
+            return true
+        }
+
+        if let extraMessages = log.extraMessages,
+           extraMessages.contains(where: { $0.title.localizedCaseInsensitiveContains(query) || $0.message.localizedCaseInsensitiveContains(query) }) {
+            return true
+        }
+
+        if let error = log.error, error.localizedDescription.localizedCaseInsensitiveContains(query) {
+            return true
+        }
+
+        return log.location.file.localizedCaseInsensitiveContains(query)
+    }
+
     deinit {
-        timer?.cancel()
+        loggingTask?.cancel()
     }
 }

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import LogBird
+
+@MainActor
+final class LogsViewModelTests: XCTestCase {
+
+    private func makeLog(message: String?, level: LBLogLevel, file: String = "LogBird/LBManager.swift") -> LBLog {
+        LBLog(
+            level: level,
+            message: message,
+            createdAt: Date().timeIntervalSince1970,
+            location: LBLocation(file: file, function: "log(_:)", line: 42),
+            source: LBSource(subsystem: "com.logbird.tests", category: "viewmodel")
+        )
+    }
+
+    func testViewModelReceivesPublishedLogs() async throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "publish")
+        let viewModel = LogsViewModel(logBird: logBird)
+
+        logBird.log("viewmodel-publishes")
+
+        for _ in 0..<50 where viewModel.logs.isEmpty {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        XCTAssertEqual(viewModel.logs.first?.message, "viewmodel-publishes")
+    }
+
+    func testFilteredLogsAppliesLevelFilter() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "level-filter"))
+        viewModel.logs = [
+            makeLog(message: "a debug message", level: .debug),
+            makeLog(message: "an error message", level: .error)
+        ]
+
+        viewModel.levelFilter = .error
+
+        XCTAssertEqual(viewModel.filteredLogs.count, 1)
+        XCTAssertEqual(viewModel.filteredLogs.first?.message, "an error message")
+    }
+
+    func testFilteredLogsAppliesSearchText() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "search"))
+        viewModel.logs = [
+            makeLog(message: "Network request finished", level: .info),
+            makeLog(message: "Cache invalidated", level: .debug)
+        ]
+
+        viewModel.searchText = "network"
+
+        XCTAssertEqual(viewModel.filteredLogs.count, 1)
+        XCTAssertEqual(viewModel.filteredLogs.first?.message, "Network request finished")
+    }
+
+    func testExportDataEncodesFilteredLogs() throws {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "export"))
+        viewModel.logs = [
+            makeLog(message: "exported", level: .warning)
+        ]
+
+        let data = try XCTUnwrap(viewModel.exportData())
+        let decoded = try JSONDecoder().decode([LBLog].self, from: data)
+
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.message, "exported")
+    }
+
+    func testLocationFileNameStripsModulePath() {
+        let location = LBLocation(file: "LogBird/LBManager.swift", function: "log(_:)", line: 42)
+
+        XCTAssertEqual(location.fileName, "LBManager.swift")
+        XCTAssertEqual(LBLocation(file: "NoSeparator.swift", function: "f()", line: 1).fileName, "NoSeparator.swift")
+    }
+}


### PR DESCRIPTION
## Summary

- **Lifecycle**: `LogsViewModel` is now a `@MainActor final` class that subscribes to `logsPublisher` once at creation. Previously every `onAppear` stacked a new Combine subscription, leaking a sink per appearance. The dead `timer` field is gone.
- **Search, filter, export, clear**: the view model owns the search text and an optional level filter and exposes `filteredLogs`. `LBLogsView` adds a `.searchable` field and a toolbar menu with a level picker, an export action (share sheet with a JSON file on iOS, save panel on macOS) and a clear action backed by `clearLogs()`.
- **Modern SwiftUI**: `NavigationStack` on iOS 16 / macOS 13 with a `NavigationView` fallback on older systems, `.listStyle(.plain)` instead of the deprecated `PlainListStyle()`, and `clipShape` instead of the deprecated `cornerRadius(_:)`.
- **Public row**: `LBLogRowView` is now public with a public init, so consumers can render a log row inside their own UI. Its background uses the new semantic `LBLogLevel.color`, which adapts to dark mode; `LBLogLevel` also gains a `symbolName` per level.
- **Compact location**: `LBLocation` exposes `fileName` (the `#fileID` value without the module path) and both the row and the console message use it.
- **Accessibility & previews**: labels and hints on the list, each row and the toolbar menu; light and dark previews for both views.
- The internal section helper was renamed to `LogSection` to avoid shadowing `SwiftUI.Section`.
- The `LBLogsView` init documents that the `LogBird` instance is captured on first creation.

## Verification

- `swift build` and `swift test` pass (9 tests, 0 failures), including 5 new tests covering publisher delivery, level filtering, text search, JSON export and `fileName`.
- `swift build -Xswiftc -strict-concurrency=complete` passes.
- `xcodebuild build -scheme LogBird -destination 'generic/platform=iOS'` passes, so the iOS-only paths (share sheet) compile.
- The Example app builds against the updated package.
