### PR TITLE
Typed log metadata, history limits and export formats

### DIFF
--- a/Sources/LogBird/Export/LBExportFormat.swift
+++ b/Sources/LogBird/Export/LBExportFormat.swift
@@ -1,0 +1,26 @@
+//
+//  LBExportFormat.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 28/07/2026.
+//
+
+import Foundation
+
+/// The available formats for exporting recorded logs.
+public enum LBExportFormat: String, Codable, CaseIterable, Sendable {
+    /// A single pretty-printed JSON array of `LBLog` entries.
+    case json
+    /// One compact JSON `LBLog` per line, for log ingestion tools.
+    case jsonLines
+    /// The same human-readable text that is sent to OSLog.
+    case plainText
+
+    public var fileExtension: String {
+        switch self {
+        case .json: return "json"
+        case .jsonLines: return "jsonl"
+        case .plainText: return "log"
+        }
+    }
+}

--- a/Sources/LogBird/Export/LBLogExporter.swift
+++ b/Sources/LogBird/Export/LBLogExporter.swift
@@ -1,0 +1,40 @@
+//
+//  LBLogExporter.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 28/07/2026.
+//
+
+import Foundation
+
+enum LBLogExporter {
+
+    private static let jsonEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    private static let jsonLinesEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    static func data(for logs: [LBLog], format: LBExportFormat, identifier: String? = nil) -> Data {
+        switch format {
+        case .json:
+            return (try? jsonEncoder.encode(logs)) ?? Data()
+        case .jsonLines:
+            let lines = logs.compactMap { log -> String? in
+                (try? jsonLinesEncoder.encode(log)).map { String(decoding: $0, as: UTF8.self) }
+            }
+            return Data(lines.joined(separator: "\n").utf8)
+        case .plainText:
+            let text = logs
+                .map { LBManager.formattedMessage(for: $0, identifier: identifier) }
+                .joined(separator: "\n\n")
+            return Data(text.utf8)
+        }
+    }
+}

--- a/Sources/LogBird/Export/LBLogExporter.swift
+++ b/Sources/LogBird/Export/LBLogExporter.swift
@@ -9,27 +9,30 @@ import Foundation
 
 enum LBLogExporter {
 
+    // Shared across threads — do not mutate after initialization.
     private static let jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return encoder
     }()
 
+    // Shared across threads — do not mutate after initialization.
     private static let jsonLinesEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         return encoder
     }()
 
-    static func data(for logs: [LBLog], format: LBExportFormat, identifier: String? = nil) -> Data {
+    static func data(for logs: [LBLog], format: LBExportFormat, identifier: String? = nil) throws -> Data {
         switch format {
         case .json:
-            return (try? jsonEncoder.encode(logs)) ?? Data()
+            return try jsonEncoder.encode(logs)
         case .jsonLines:
-            let lines = logs.compactMap { log -> String? in
-                (try? jsonLinesEncoder.encode(log)).map { String(decoding: $0, as: UTF8.self) }
+            let lines = try logs.map { log in
+                String(decoding: try jsonLinesEncoder.encode(log), as: UTF8.self)
             }
-            return Data(lines.joined(separator: "\n").utf8)
+            let text = lines.isEmpty ? "" : lines.joined(separator: "\n") + "\n"
+            return Data(text.utf8)
         case .plainText:
             let text = logs
                 .map { LBManager.formattedMessage(for: $0, identifier: identifier) }

--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -7,12 +7,16 @@
 
 import Foundation
 
-public struct LBLog: Codable, Identifiable {
+/// A single recorded log entry.
+///
+/// Equality and hashing include `id`, so two entries are equal only when they
+/// represent the same recorded log.
+public struct LBLog: Codable, Identifiable, Hashable, Sendable {
     public let id: String
     public let level: LBLogLevel
     public let message: String?
     public let extraMessages: [LBExtraMessage]?
-    public let additionalInfo: [String: String]?
+    public let additionalInfo: [String: LBValue]?
     public let error: LBError?
     public let createdAt: Double
     public let location: LBLocation
@@ -23,7 +27,7 @@ public struct LBLog: Codable, Identifiable {
         level: LBLogLevel,
         message: String? = nil,
         extraMessages: [LBExtraMessage]? = nil,
-        additionalInfo: [String: String]? = nil,
+        additionalInfo: [String: LBValue]? = nil,
         error: LBError? = nil,
         createdAt: Double,
         location: LBLocation,
@@ -41,7 +45,7 @@ public struct LBLog: Codable, Identifiable {
     }
 }
 
-public struct LBSource: Codable {
+public struct LBSource: Codable, Hashable, Sendable {
     public let subsystem: String
     public let category: String
 
@@ -51,7 +55,7 @@ public struct LBSource: Codable {
     }
 }
 
-public struct LBLocation: Codable {
+public struct LBLocation: Codable, Hashable, Sendable {
     public let file: String
     public let function: String
     public let line: Int
@@ -68,41 +72,57 @@ public struct LBLocation: Codable {
     }
 }
 
-public struct LBError: Codable {
+public struct LBError: Codable, Hashable, Sendable {
     public let domain: String
     public let code: Int
+    public let type: String
     public let localizedDescription: String
     public let userInfo: [String: String]?
 
-    public init(domain: String, code: Int, localizedDescription: String, userInfo: [String: String]? = nil) {
+    public init(domain: String, code: Int, type: String, localizedDescription: String, userInfo: [String: String]? = nil) {
         self.domain = domain
         self.code = code
+        self.type = type
         self.localizedDescription = localizedDescription
         self.userInfo = userInfo
     }
 }
 
-public struct LBExtraMessage: Codable, Hashable {
+public struct LBExtraMessage: Codable, Identifiable, Sendable {
+    public let id: UUID
     public let title: String
     public let message: String
 
-    public init(title: String, message: String) {
+    public init(id: UUID = UUID(), title: String, message: String) {
+        self.id = id
         self.title = title
         self.message = message
     }
 }
 
-public extension LBLog {
-    func prettyJSON() -> String? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
+extension LBExtraMessage: Hashable {
+    /// Equality and hashing are content-based; `id` only gives each instance a
+    /// unique identity for list rendering.
+    public static func == (lhs: LBExtraMessage, rhs: LBExtraMessage) -> Bool {
+        lhs.title == rhs.title && lhs.message == rhs.message
+    }
 
-        do {
-            let jsonData = try encoder.encode(self)
-            return String(data: jsonData, encoding: .utf8) ?? ""
-        } catch {
-            print("Error encoding LBLog to JSON:", error)
-            return nil
-        }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(message)
+    }
+}
+
+public extension LBLog {
+    private static let prettyJSONEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    /// Returns a deterministic, pretty-printed JSON representation of the log.
+    func prettyJSON() throws -> String {
+        let data = try Self.prettyJSONEncoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -22,7 +22,7 @@ public struct LBLog: Codable, Identifiable, Hashable, Sendable {
     public let location: LBLocation
     public let source: LBSource
 
-    public init(
+    init(
         id: String = UUID().uuidString,
         level: LBLogLevel,
         message: String? = nil,
@@ -49,7 +49,7 @@ public struct LBSource: Codable, Hashable, Sendable {
     public let subsystem: String
     public let category: String
 
-    public init(subsystem: String, category: String) {
+    init(subsystem: String, category: String) {
         self.subsystem = subsystem
         self.category = category
     }
@@ -60,7 +60,7 @@ public struct LBLocation: Codable, Hashable, Sendable {
     public let function: String
     public let line: Int
 
-    public init(file: String, function: String, line: Int) {
+    init(file: String, function: String, line: Int) {
         self.file = file
         self.function = function
         self.line = line
@@ -79,7 +79,7 @@ public struct LBError: Codable, Hashable, Sendable {
     public let localizedDescription: String
     public let userInfo: [String: String]?
 
-    public init(domain: String, code: Int, type: String, localizedDescription: String, userInfo: [String: String]? = nil) {
+    init(domain: String, code: Int, type: String, localizedDescription: String, userInfo: [String: String]? = nil) {
         self.domain = domain
         self.code = code
         self.type = type

--- a/Sources/LogBird/LBLogLevel.swift
+++ b/Sources/LogBird/LBLogLevel.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-public enum LBLogLevel: String, Codable, CaseIterable {
+public enum LBLogLevel: String, Codable, CaseIterable, Sendable {
     case debug, info, warning, error, critical
     
     public var osLogType: OSLogType {
@@ -50,5 +50,11 @@ public enum LBLogLevel: String, Codable, CaseIterable {
         case .error: return "xmark.octagon"
         case .critical: return "flame"
         }
+    }
+}
+
+extension LBLogLevel: CustomStringConvertible {
+    public var description: String {
+        rawValue
     }
 }

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -10,51 +10,72 @@ import OSLog
 import Combine
 
 final class LBManager: @unchecked Sendable {
-    
+
     private let logger: Logger
     private var identifier: String?
     private let dispatchQueue: DispatchQueue = DispatchQueue(label: "com.logbird.accessQueue")
     // Publishing runs on its own serial queue so subscriber callbacks never execute
     // while the state queue is held (avoids re-entrancy deadlocks).
     private let publishQueue: DispatchQueue = DispatchQueue(label: "com.logbird.publishQueue")
-    
+
     private let source: LBSource
-    
+
     private var logs: [LBLog] = []
     private let logsSubject = CurrentValueSubject<[LBLog], Never>([])
     var logsPublisher: AnyPublisher<[LBLog], Never> {
         logsSubject.eraseToAnyPublisher()
     }
-    
-    static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS ZZZZ"
-        formatter.timeZone = TimeZone.current
-        formatter.locale = Locale.current
-        return formatter
+
+    static let dateStyle: Date.ISO8601FormatStyle = {
+        var style = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+        style.timeZone = .current
+        return style
     }()
-    
-    init(subsystem: String, category: String) {
+
+    private var storedMaxLogs: Int
+
+    /// The maximum number of entries kept in memory. Once the limit is reached,
+    /// the oldest entries are discarded. Values below 1 are treated as 1.
+    var maxLogs: Int {
+        get {
+            dispatchQueue.sync { storedMaxLogs }
+        }
+        set {
+            dispatchQueue.sync {
+                self.storedMaxLogs = max(1, newValue)
+                self.trimLogs()
+                let snapshot = self.logs
+                self.publishQueue.async { self.logsSubject.send(snapshot) }
+            }
+        }
+    }
+
+    var currentLogs: [LBLog] {
+        dispatchQueue.sync { logs }
+    }
+
+    init(subsystem: String, category: String, maxLogs: Int = 1000) {
         let source = LBSource(subsystem: subsystem, category: category)
         self.logger = Logger(subsystem: source.subsystem, category: source.category)
         self.source = source
+        self.storedMaxLogs = max(1, maxLogs)
     }
-    
+
     func setIdentifier(_ value: String?) {
         dispatchQueue.sync {
             self.identifier = value
         }
     }
-    
+
     func log(_ message: String? = nil,
              extraMessages: [LBExtraMessage]? = nil,
-             additionalInfo: [String: Any]? = nil,
+             additionalInfo: [String: LBValue]? = nil,
              error: Error? = nil,
              level: LBLogLevel = .debug,
              file: String = #fileID,
              function: String = #function,
              line: Int = #line) {
-        
+
         // `buildLogData` only reads immutable `source` and the supplied parameters.
         let log = buildLogData(message: message,
                                extraMessages: extraMessages,
@@ -64,17 +85,18 @@ final class LBManager: @unchecked Sendable {
                                file: file,
                                function: function,
                                line: line)
-        
+
         // Serialize identifier read and log mutation to keep state consistent.
         dispatchQueue.sync {
-            let logMessage = self.generateLogMessage(log, identifier: self.identifier)
-            self.logger.log(level: level.osLogType, "\(logMessage)")
+            let logMessage = Self.formattedMessage(for: log, identifier: self.identifier)
+            self.logger.log(level: level.osLogType, "\(logMessage, privacy: .public)")
             self.logs.insert(log, at: 0)
+            self.trimLogs()
             let snapshot = self.logs
             self.publishQueue.async { self.logsSubject.send(snapshot) }
         }
     }
-    
+
     func clearLogs() {
         dispatchQueue.sync {
             self.logs = []
@@ -82,68 +104,156 @@ final class LBManager: @unchecked Sendable {
         }
     }
 
+    func exportLogs(format: LBExportFormat) -> Data {
+        let (logs, identifier) = dispatchQueue.sync { (self.logs, self.identifier) }
+        return LBLogExporter.data(for: logs, format: format, identifier: identifier)
+    }
+
+    func writeLogs(to url: URL, format: LBExportFormat) throws {
+        try exportLogs(format: format).write(to: url, options: .atomic)
+    }
+
+    /// Keeps only the newest `storedMaxLogs` entries. Must be called on `dispatchQueue`.
+    private func trimLogs() {
+        if logs.count > storedMaxLogs {
+            logs.removeLast(logs.count - storedMaxLogs)
+        }
+    }
+
     private func buildLogData(message: String? = nil,
                               extraMessages: [LBExtraMessage]? = nil,
-                              additionalInfo: [String: Any]? = nil,
+                              additionalInfo: [String: LBValue]? = nil,
                               error: Error? = nil,
                               level: LBLogLevel,
                               file: String,
                               function: String,
                               line: Int) -> LBLog {
-        
+
         let errorData: LBError? = errorToLBError(error) ?? nil
-        
-        let additionalInfoString = additionalInfo?.compactMapValues { "\($0)" }
-        
+
         let log = LBLog(
             level: level,
             message: message,
             extraMessages: extraMessages,
-            additionalInfo: additionalInfoString,
+            additionalInfo: additionalInfo,
             error: errorData,
             createdAt: Date().timeIntervalSince1970,
             location: LBLocation(file: file, function: function, line: line),
             source: LBSource(subsystem: source.subsystem, category: source.category)
         )
-        
+
         return log
     }
-    
+
     private func errorToLBError(_ error: Error?) -> LBError? {
         guard let error else { return nil }
         let nsError = error as NSError
-        let userInfoString = nsError.userInfo.compactMapValues { "\($0)" }
-        
+
+        var userInfo = nsError.userInfo
+        if let decodingError = error as? DecodingError {
+            userInfo.merge(Self.contextInfo(for: decodingError)) { _, new in new }
+        } else if let encodingError = error as? EncodingError {
+            userInfo.merge(Self.contextInfo(for: encodingError)) { _, new in new }
+        }
+
+        let userInfoString = userInfo.isEmpty ? nil : userInfo.mapValues(Self.userInfoString(from:))
+
         return LBError(
             domain: nsError.domain,
             code: nsError.code,
+            type: String(describing: Swift.type(of: error)),
             localizedDescription: nsError.localizedDescription,
             userInfo: userInfoString
         )
     }
-    
-    private func generateLogMessage(_ log: LBLog, identifier: String?) -> String {
+
+    private static func contextInfo(for error: DecodingError) -> [String: Any] {
+        var info: [String: Any] = [:]
+        let context: DecodingError.Context
+
+        switch error {
+        case .typeMismatch(_, let errorContext),
+             .valueNotFound(_, let errorContext),
+             .dataCorrupted(let errorContext):
+            context = errorContext
+        case .keyNotFound(let codingKey, let errorContext):
+            info["missingKey"] = codingKey.stringValue
+            context = errorContext
+        @unknown default:
+            return info
+        }
+
+        info["codingPath"] = context.codingPath.map(\.stringValue).joined(separator: ".")
+        info["debugDescription"] = context.debugDescription
+        if let underlyingError = context.underlyingError {
+            info["underlyingError"] = underlyingError
+        }
+        return info
+    }
+
+    private static func contextInfo(for error: EncodingError) -> [String: Any] {
+        switch error {
+        case .invalidValue(_, let context):
+            var info: [String: Any] = [
+                "codingPath": context.codingPath.map(\.stringValue).joined(separator: "."),
+                "debugDescription": context.debugDescription
+            ]
+            if let underlyingError = context.underlyingError {
+                info["underlyingError"] = underlyingError
+            }
+            return info
+        @unknown default:
+            return [:]
+        }
+    }
+
+    /// Converts a `userInfo` value into a readable string. Objects without a
+    /// meaningful description are replaced by a placeholder instead of the
+    /// default `<ClassName: 0x...>` representation.
+    static func userInfoString(from value: Any) -> String {
+        switch value {
+        case let string as String:
+            return string
+        case let error as NSError:
+            return "\(error.domain) (\(error.code)): \(error.localizedDescription)"
+        case let url as URL:
+            return url.absoluteString
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue ? "true" : "false"
+            }
+            return number.stringValue
+        default:
+            let description = String(describing: value)
+            if description.hasPrefix("<"), description.hasSuffix(">") {
+                return "<non-string>"
+            }
+            return description
+        }
+    }
+
+    static func formattedMessage(for log: LBLog, identifier: String?) -> String {
         var logMessage: String = ""
         let spacing: String = "    "
-        
+
         // Header
         var header: String = "\(log.level.emoji) \(log.level.rawValue.uppercased()) LogBird: \n"
         if let identifier {
             header = "\(identifier) \(header)"
         }
-        
+
         logMessage = "\(logMessage)\(header)"
-        
+
         // Created At
-        let createdAt: String = "Created at:\n\(spacing)\(LBManager.dateFormatter.string(from: Date(timeIntervalSince1970: log.createdAt)))\n"
+        let createdAt: String = "Created at:\n\(spacing)\(LBManager.dateStyle.format(Date(timeIntervalSince1970: log.createdAt)))\n"
         logMessage = "\(logMessage)\(createdAt)"
-        
+
         // Message
         if let message = log.message {
             let info: String = "Message:\n\(spacing)\(message)\n"
             logMessage = "\(logMessage)\(info)"
         }
-        
+
         // Extra Messages
         if let extraMessages = log.extraMessages {
             for extraMessage in extraMessages {
@@ -151,7 +261,7 @@ final class LBManager: @unchecked Sendable {
                 logMessage = "\(logMessage)\(message)"
             }
         }
-        
+
         // Additional Info
         if let additionalInfo = log.additionalInfo {
             var info: String = "Additional Info:\n"
@@ -162,13 +272,14 @@ final class LBManager: @unchecked Sendable {
             }
             logMessage = "\(logMessage)\(info)"
         }
-        
+
         // Error
         if let error = log.error {
             let domain: String = "Domain: \(error.domain)\n"
             let code: String = "Code: \(error.code)\n"
+            let type: String = "Type: \(error.type)\n"
             var userInfoString: String = ""
-            
+
             if let userInfo = error.userInfo {
                 userInfoString = "User Info:\n"
                 for key in userInfo.keys {
@@ -177,28 +288,28 @@ final class LBManager: @unchecked Sendable {
                     }
                 }
             }
-            
-            var errorString: String = "Error:\n\(spacing)\(domain)\(spacing)\(code)"
+
+            var errorString: String = "Error:\n\(spacing)\(type)\(spacing)\(domain)\(spacing)\(code)"
             if !userInfoString.isEmpty {
                 errorString = "\(errorString)\(spacing)\(userInfoString)"
             }
-            
+
             logMessage = "\(logMessage)\(errorString)"
         }
-        
+
         // Source
         let subsystem: String = "Subsystem: \(log.source.subsystem)\n"
         let category: String = "Category: \(log.source.category)\n"
         let source: String = "Source: \n\(spacing)\(subsystem)\(spacing)\(category)"
         logMessage = "\(logMessage)\(source)"
-        
+
         // Location
         let file: String = "File: \(log.location.fileName)\n"
         let function: String = "Function: \(log.location.function)\n"
         let line: String = "Line: \(log.location.line)\n"
         let location: String = "Location:\n\(spacing)\(file)\(spacing)\(function)\(spacing)\(line)"
         logMessage = "\(logMessage)\(location)"
-        
+
         return logMessage
     }
 }

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -43,15 +43,18 @@ final class LBManager: @unchecked Sendable {
         set {
             dispatchQueue.sync {
                 self.storedMaxLogs = max(1, newValue)
+                let countBeforeTrim = self.logs.count
                 self.trimLogs()
-                let snapshot = self.logs
-                self.publishQueue.async { self.logsSubject.send(snapshot) }
+                if self.logs.count != countBeforeTrim {
+                    let snapshot = self.logs
+                    self.publishQueue.async { self.logsSubject.send(snapshot) }
+                }
             }
         }
     }
 
-    var currentLogs: [LBLog] {
-        dispatchQueue.sync { logs }
+    var currentIdentifier: String? {
+        dispatchQueue.sync { identifier }
     }
 
     init(subsystem: String, category: String, maxLogs: Int = 1000) {
@@ -104,9 +107,9 @@ final class LBManager: @unchecked Sendable {
         }
     }
 
-    func exportLogs(format: LBExportFormat) -> Data {
+    func exportLogs(format: LBExportFormat) throws -> Data {
         let (logs, identifier) = dispatchQueue.sync { (self.logs, self.identifier) }
-        return LBLogExporter.data(for: logs, format: format, identifier: identifier)
+        return try LBLogExporter.data(for: logs, format: format, identifier: identifier)
     }
 
     func writeLogs(to url: URL, format: LBExportFormat) throws {
@@ -154,6 +157,12 @@ final class LBManager: @unchecked Sendable {
             userInfo.merge(Self.contextInfo(for: decodingError)) { _, new in new }
         } else if let encodingError = error as? EncodingError {
             userInfo.merge(Self.contextInfo(for: encodingError)) { _, new in new }
+        }
+
+        // The extracted context replaces the bridged keys, which would stringify poorly.
+        if error is DecodingError || error is EncodingError {
+            userInfo.removeValue(forKey: "NSCodingPath")
+            userInfo.removeValue(forKey: "NSDebugDescription")
         }
 
         let userInfoString = userInfo.isEmpty ? nil : userInfo.mapValues(Self.userInfoString(from:))
@@ -225,7 +234,8 @@ final class LBManager: @unchecked Sendable {
             return number.stringValue
         default:
             let description = String(describing: value)
-            if description.hasPrefix("<"), description.hasSuffix(">") {
+            // The default NSObject description carries no information (`<ClassName: 0x...>`).
+            if description.hasPrefix("<"), description.contains(": 0x") {
                 return "<non-string>"
             }
             return description
@@ -265,7 +275,7 @@ final class LBManager: @unchecked Sendable {
         // Additional Info
         if let additionalInfo = log.additionalInfo {
             var info: String = "Additional Info:\n"
-            for key in additionalInfo.keys {
+            for key in additionalInfo.keys.sorted() {
                 if let value = additionalInfo[key] {
                     info = "\(info)\(spacing) \(key): \(value)\n"
                 }
@@ -282,7 +292,7 @@ final class LBManager: @unchecked Sendable {
 
             if let userInfo = error.userInfo {
                 userInfoString = "User Info:\n"
-                for key in userInfo.keys {
+                for key in userInfo.keys.sorted() {
                     if let value = userInfo[key] {
                         userInfoString = "\(userInfoString)\(spacing)\(spacing)\(key): \(value)\n"
                     }

--- a/Sources/LogBird/LBValue.swift
+++ b/Sources/LogBird/LBValue.swift
@@ -1,0 +1,86 @@
+//
+//  LBValue.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 28/07/2026.
+//
+
+import Foundation
+
+/// A typed value for `additionalInfo` metadata.
+///
+/// Values keep their original type when encoded to JSON, so exported logs
+/// contain real numbers, booleans and strings instead of stringified output.
+public enum LBValue: Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case url(URL)
+}
+
+extension LBValue: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported additional info value")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let string): try container.encode(string)
+        case .int(let int): try container.encode(int)
+        case .double(let double): try container.encode(double)
+        case .bool(let bool): try container.encode(bool)
+        case .url(let url): try container.encode(url.absoluteString)
+        }
+    }
+}
+
+extension LBValue: Hashable {}
+
+extension LBValue: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .string(let string): return string
+        case .int(let int): return String(int)
+        case .double(let double): return String(double)
+        case .bool(let bool): return String(bool)
+        case .url(let url): return url.absoluteString
+        }
+    }
+}
+
+extension LBValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension LBValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .int(value)
+    }
+}
+
+extension LBValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+extension LBValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}

--- a/Sources/LogBird/LBValue.swift
+++ b/Sources/LogBird/LBValue.swift
@@ -11,6 +11,11 @@ import Foundation
 ///
 /// Values keep their original type when encoded to JSON, so exported logs
 /// contain real numbers, booleans and strings instead of stringified output.
+///
+/// Decoding is best-effort: JSON has no distinct URL type, so URLs decode as
+/// `.string`, and whole-number doubles (e.g. `12.0`, encoded as `12`) decode
+/// as `.int`. Encoding a non-finite double (NaN or infinity) throws, as with
+/// any `JSONEncoder`.
 public enum LBValue: Sendable {
     case string(String)
     case int(Int)

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -12,8 +12,8 @@ public class LogBird: @unchecked Sendable {
 
     private let manager: LBManager
 
-    public init(subsystem: String, category: String) {
-        manager = LBManager(subsystem: subsystem, category: category)
+    public init(subsystem: String, category: String, maxLogs: Int = 1000) {
+        manager = LBManager(subsystem: subsystem, category: category, maxLogs: maxLogs)
     }
 }
 
@@ -25,16 +25,30 @@ extension LogBird {
         shared.logsPublisher
     }
 
+    /// The maximum number of entries kept in memory by `shared`.
+    static public var maxLogs: Int {
+        get { shared.maxLogs }
+        set { shared.maxLogs = newValue }
+    }
+
     static public func setIdentifier(_ identifier: String?) {
         shared.setIdentifier(identifier)
     }
 
-    static public func log(_ message: String, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: Any]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    static public func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         shared.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
     static public func clearLogs() {
         shared.clearLogs()
+    }
+
+    static public func exportLogs(format: LBExportFormat = .json) -> Data {
+        shared.exportLogs(format: format)
+    }
+
+    static public func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
+        try shared.writeLogs(to: url, format: format)
     }
 }
 
@@ -45,15 +59,32 @@ extension LogBird {
         manager.logsPublisher
     }
 
+    /// The maximum number of entries kept in memory. Once the limit is reached,
+    /// the oldest entries are discarded.
+    public var maxLogs: Int {
+        get { manager.maxLogs }
+        set { manager.maxLogs = newValue }
+    }
+
     public func setIdentifier(_ value: String?) {
         manager.setIdentifier(value)
     }
 
-    public func log(_ message: String, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: Any]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    public func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         manager.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
     public func clearLogs() {
         manager.clearLogs()
+    }
+
+    /// Exports the recorded history in the given format.
+    public func exportLogs(format: LBExportFormat = .json) -> Data {
+        manager.exportLogs(format: format)
+    }
+
+    /// Writes the recorded history to a file in the given format.
+    public func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
+        try manager.writeLogs(to: url, format: format)
     }
 }

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -43,8 +43,8 @@ extension LogBird {
         shared.clearLogs()
     }
 
-    static public func exportLogs(format: LBExportFormat = .json) -> Data {
-        shared.exportLogs(format: format)
+    static public func exportLogs(format: LBExportFormat = .json) throws -> Data {
+        try shared.exportLogs(format: format)
     }
 
     static public func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
@@ -60,7 +60,8 @@ extension LogBird {
     }
 
     /// The maximum number of entries kept in memory. Once the limit is reached,
-    /// the oldest entries are discarded.
+    /// the oldest entries are discarded. Lowering the value trims the existing
+    /// history immediately and cannot be undone.
     public var maxLogs: Int {
         get { manager.maxLogs }
         set { manager.maxLogs = newValue }
@@ -78,9 +79,16 @@ extension LogBird {
         manager.clearLogs()
     }
 
+    var currentIdentifier: String? {
+        manager.currentIdentifier
+    }
+
     /// Exports the recorded history in the given format.
-    public func exportLogs(format: LBExportFormat = .json) -> Data {
-        manager.exportLogs(format: format)
+    ///
+    /// - Throws: an `EncodingError` if a log value cannot be encoded
+    ///   (e.g. a non-finite double in `additionalInfo`).
+    public func exportLogs(format: LBExportFormat = .json) throws -> Data {
+        try manager.exportLogs(format: format)
     }
 
     /// Writes the recorded history to a file in the given format.

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -16,11 +16,13 @@ import UniformTypeIdentifiers
 
 enum LBLogExport {
 
-    static let fileName = "logbird-logs.json"
+    static func fileName(for format: LBExportFormat) -> String {
+        "logbird-logs.\(format.fileExtension)"
+    }
 
-    static func writeTemporaryFile(data: Data) -> URL? {
+    static func writeTemporaryFile(data: Data, format: LBExportFormat) -> URL? {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("logbird-logs-\(UUID().uuidString).json")
+            .appendingPathComponent("logbird-logs-\(UUID().uuidString).\(format.fileExtension)")
         do {
             try data.write(to: url, options: .atomic)
             return url
@@ -31,13 +33,22 @@ enum LBLogExport {
 
     #if os(macOS)
     @MainActor
-    static func presentSavePanel(data: Data) {
+    static func presentSavePanel(data: Data, format: LBExportFormat) {
         let panel = NSSavePanel()
-        panel.allowedContentTypes = [.json]
-        panel.nameFieldStringValue = fileName
+        panel.allowedContentTypes = [contentType(for: format)]
+        panel.nameFieldStringValue = fileName(for: format)
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             try? data.write(to: url)
+        }
+    }
+
+    private static func contentType(for format: LBExportFormat) -> UTType {
+        switch format {
+        case .json:
+            return .json
+        case .jsonLines, .plainText:
+            return .plainText
         }
     }
     #endif

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -39,7 +39,7 @@ enum LBLogExport {
         panel.nameFieldStringValue = fileName(for: format)
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
-            try? data.write(to: url)
+            try? data.write(to: url, options: .atomic)
         }
     }
 
@@ -47,7 +47,11 @@ enum LBLogExport {
         switch format {
         case .json:
             return .json
-        case .jsonLines, .plainText:
+        case .jsonLines:
+            // No system type claims the .jsonl extension; declaring it as plain
+            // text keeps the save panel from appending .txt to the file name.
+            return UTType(filenameExtension: format.fileExtension, conformingTo: .plainText) ?? .plainText
+        case .plainText:
             return .plainText
         }
     }

--- a/Sources/LogBird/LogView/LBLogRowView.swift
+++ b/Sources/LogBird/LogView/LBLogRowView.swift
@@ -7,14 +7,14 @@
 
 import SwiftUI
 
-public struct LBLogRowView: View {
-    public let log: LBLog
+struct LBLogRowView: View {
+    let log: LBLog
 
-    public init(log: LBLog) {
+    init(log: LBLog) {
         self.log = log
     }
 
-    public var body: some View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             let date = LBManager.dateStyle.format(Date(timeIntervalSince1970: log.createdAt))
             Header(createdAt: date, level: log.level)

--- a/Sources/LogBird/LogView/LBLogRowView.swift
+++ b/Sources/LogBird/LogView/LBLogRowView.swift
@@ -16,7 +16,7 @@ public struct LBLogRowView: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            let date = LBManager.dateFormatter.string(from: Date(timeIntervalSince1970: log.createdAt))
+            let date = LBManager.dateStyle.format(Date(timeIntervalSince1970: log.createdAt))
             Header(createdAt: date, level: log.level)
 
             if let message = log.message, !message.isEmpty {
@@ -79,7 +79,7 @@ private extension LBLogRowView {
 
     @ViewBuilder
     func ExtraMessages(_ extraMessages: [LBExtraMessage]) -> some View {
-        ForEach(extraMessages, id: \.self) { value in
+        ForEach(extraMessages) { value in
             LogSection(title: value.title) {
                 Text(value.message)
             }
@@ -87,11 +87,11 @@ private extension LBLogRowView {
     }
 
     @ViewBuilder
-    func AdditionalInfo(_ additionalInfo: [String: String]) -> some View {
+    func AdditionalInfo(_ additionalInfo: [String: LBValue]) -> some View {
         LogSection(title: "Additional Info") {
             ForEach(additionalInfo.keys.sorted(), id: \.self) { key in
                 if let value = additionalInfo[key] {
-                    InfoRow(label: "\(key):", value: value)
+                    InfoRow(label: "\(key):", value: value.description)
                 }
             }
         }
@@ -100,6 +100,8 @@ private extension LBLogRowView {
     @ViewBuilder
     func LogError(_ error: LBError) -> some View {
         LogSection(title: "Error") {
+            InfoRow(label: "Type:", value: error.type)
+
             InfoRow(label: "Domain:", value: error.domain)
 
             InfoRow(label: "Code:", value: "\(error.code)")

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -70,8 +70,12 @@ public struct LBLogsView: View {
 
                 Divider()
 
-                Button {
-                    exportLogs()
+                Menu {
+                    ForEach(LBExportFormat.allCases, id: \.self) { format in
+                        Button(format.menuTitle) {
+                            exportLogs(format: format)
+                        }
+                    }
                 } label: {
                     Label("Export Logs", systemImage: "square.and.arrow.up")
                 }
@@ -89,15 +93,25 @@ public struct LBLogsView: View {
         }
     }
 
-    private func exportLogs() {
-        guard let data = viewModel.exportData() else { return }
+    private func exportLogs(format: LBExportFormat) {
+        let data = viewModel.exportData(format: format)
         #if os(iOS)
-        if let url = LBLogExport.writeTemporaryFile(data: data) {
+        if let url = LBLogExport.writeTemporaryFile(data: data, format: format) {
             exportFile = ExportFile(url: url)
         }
         #elseif os(macOS)
-        LBLogExport.presentSavePanel(data: data)
+        LBLogExport.presentSavePanel(data: data, format: format)
         #endif
+    }
+}
+
+private extension LBExportFormat {
+    var menuTitle: String {
+        switch self {
+        case .json: return "JSON"
+        case .jsonLines: return "JSON Lines"
+        case .plainText: return "Plain Text"
+        }
     }
 }
 

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -94,7 +94,7 @@ public struct LBLogsView: View {
     }
 
     private func exportLogs(format: LBExportFormat) {
-        let data = viewModel.exportData(format: format)
+        guard let data = viewModel.exportData(format: format) else { return }
         #if os(iOS)
         if let url = LBLogExport.writeTemporaryFile(data: data, format: format) {
             exportFile = ExportFile(url: url)

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -33,10 +33,8 @@ final class LogsViewModel: ObservableObject {
         logBird.clearLogs()
     }
 
-    func exportData() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        return try? encoder.encode(filteredLogs)
+    func exportData(format: LBExportFormat = .json) -> Data {
+        LBLogExporter.data(for: filteredLogs, format: format)
     }
 
     private func subscribeToLogs() {

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -33,8 +33,8 @@ final class LogsViewModel: ObservableObject {
         logBird.clearLogs()
     }
 
-    func exportData(format: LBExportFormat = .json) -> Data {
-        LBLogExporter.data(for: filteredLogs, format: format)
+    func exportData(format: LBExportFormat = .json) -> Data? {
+        try? LBLogExporter.data(for: filteredLogs, format: format, identifier: logBird.currentIdentifier)
     }
 
     private func subscribeToLogs() {

--- a/Tests/LogBirdTests/LBLogTests.swift
+++ b/Tests/LogBirdTests/LBLogTests.swift
@@ -48,6 +48,26 @@ final class LBLogTests: XCTestCase {
         XCTAssertEqual(decoded, values)
     }
 
+    /// JSON has no distinct URL or whole-number-double type: both decode back
+    /// as `.string` and `.int` respectively. This pins that documented contract.
+    func testLBValueRoundTripLossyCases() throws {
+        let values: [String: LBValue] = [
+            "wholeDouble": .double(12.0),
+            "site": .url(URL(string: "https://example.com")!)
+        ]
+
+        let data = try JSONEncoder().encode(values)
+        let decoded = try JSONDecoder().decode([String: LBValue].self, from: data)
+
+        XCTAssertEqual(decoded["wholeDouble"], .int(12))
+        XCTAssertEqual(decoded["site"], .string("https://example.com"))
+    }
+
+    func testLBValueDecodeFailsForUnsupportedPayloads() {
+        XCTAssertThrowsError(try JSONDecoder().decode(LBValue.self, from: Data("[1, 2]".utf8)))
+        XCTAssertThrowsError(try JSONDecoder().decode(LBValue.self, from: Data(#"{"a": 1}"#.utf8)))
+    }
+
     func testLBValueExpressibleByLiterals() {
         let values: [String: LBValue] = ["count": 12, "ratio": 1.5, "flag": true, "name": "twelve"]
 

--- a/Tests/LogBirdTests/LBLogTests.swift
+++ b/Tests/LogBirdTests/LBLogTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import LogBird
+
+final class LBLogTests: XCTestCase {
+
+    private func makeLog(id: String = "fixed-id", additionalInfo: [String: LBValue]? = nil) -> LBLog {
+        LBLog(
+            id: id,
+            level: .warning,
+            message: "hello",
+            additionalInfo: additionalInfo,
+            createdAt: 123.25,
+            location: LBLocation(file: "LogBird/LBManager.swift", function: "log(_:)", line: 42),
+            source: LBSource(subsystem: "com.logbird.tests", category: "models")
+        )
+    }
+
+    func testLBValuePreservesTypesWhenEncodedToJSON() throws {
+        let values: [String: LBValue] = [
+            "count": .int(12),
+            "ratio": .double(1.5),
+            "flag": .bool(true),
+            "name": .string("twelve"),
+            "site": .url(URL(string: "https://example.com")!)
+        ]
+
+        let data = try JSONEncoder().encode(values)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["count"] as? Int, 12)
+        XCTAssertEqual(object["ratio"] as? Double, 1.5)
+        XCTAssertEqual(object["flag"] as? Bool, true)
+        XCTAssertEqual(object["name"] as? String, "twelve")
+        XCTAssertEqual(object["site"] as? String, "https://example.com")
+    }
+
+    func testLBValueCodableRoundTrip() throws {
+        let values: [String: LBValue] = [
+            "count": .int(12),
+            "ratio": .double(1.5),
+            "flag": .bool(true),
+            "name": .string("twelve")
+        ]
+
+        let data = try JSONEncoder().encode(values)
+        let decoded = try JSONDecoder().decode([String: LBValue].self, from: data)
+
+        XCTAssertEqual(decoded, values)
+    }
+
+    func testLBValueExpressibleByLiterals() {
+        let values: [String: LBValue] = ["count": 12, "ratio": 1.5, "flag": true, "name": "twelve"]
+
+        XCTAssertEqual(values["count"], .int(12))
+        XCTAssertEqual(values["ratio"], .double(1.5))
+        XCTAssertEqual(values["flag"], .bool(true))
+        XCTAssertEqual(values["name"], .string("twelve"))
+    }
+
+    func testLBLogEqualityAndHashingIncludeID() {
+        let first = makeLog()
+        let sameID = makeLog()
+        let differentID = makeLog(id: "other-id")
+
+        XCTAssertEqual(first, sameID)
+        XCTAssertEqual(first.hashValue, sameID.hashValue)
+        XCTAssertNotEqual(first, differentID)
+        XCTAssertEqual(Set([first, sameID, differentID]).count, 2)
+    }
+
+    func testLBExtraMessageHasUniqueIdentityWithContentEquality() {
+        let first = LBExtraMessage(title: "title", message: "message")
+        let second = LBExtraMessage(title: "title", message: "message")
+
+        XCTAssertEqual(first, second)
+        XCTAssertNotEqual(first.id, second.id)
+    }
+
+    func testLBLogLevelDescription() {
+        XCTAssertEqual(LBLogLevel.debug.description, "debug")
+        XCTAssertEqual(LBLogLevel.critical.description, "critical")
+        XCTAssertEqual(String(describing: LBLogLevel.warning), "warning")
+    }
+
+    func testPrettyJSONRoundTrips() throws {
+        let log = makeLog(additionalInfo: ["count": .int(3)])
+
+        let json = try log.prettyJSON()
+        let decoded = try JSONDecoder().decode(LBLog.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded, log)
+    }
+
+    func testPrettyJSONHasSortedKeys() throws {
+        let json = try makeLog(additionalInfo: ["count": .int(3)]).prettyJSON()
+
+        let additionalInfoIndex = try XCTUnwrap(json.range(of: "\"additionalInfo\"")).lowerBound
+        let createdAtIndex = try XCTUnwrap(json.range(of: "\"createdAt\"")).lowerBound
+        let idIndex = try XCTUnwrap(json.range(of: "\"id\"")).lowerBound
+
+        XCTAssertLessThan(additionalInfoIndex, createdAtIndex)
+        XCTAssertLessThan(createdAtIndex, idIndex)
+    }
+
+    func testDateStyleProducesISO8601Output() {
+        let formatted = LBManager.dateStyle.format(Date(timeIntervalSince1970: 1_700_000_000))
+
+        let pattern = #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:?\d{2})$"#
+        XCTAssertNotNil(formatted.range(of: pattern, options: .regularExpression), "Unexpected date format: \(formatted)")
+    }
+}

--- a/Tests/LogBirdTests/LBManagerTests.swift
+++ b/Tests/LogBirdTests/LBManagerTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import LogBird
+
+final class LBManagerTests: XCTestCase {
+
+    /// Waits until `logsPublisher` reports at least `expectedCount` entries and
+    /// returns the latest snapshot.
+    private func waitForLogs(of logBird: LogBird, count expectedCount: Int, timeout: TimeInterval = 5) -> [LBLog] {
+        let expectation = expectation(description: "logs reach \(expectedCount)")
+        var latest: [LBLog] = []
+        var fulfilled = false
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if !fulfilled, logs.count >= expectedCount {
+                fulfilled = true
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: timeout)
+        cancellable.cancel()
+        return latest
+    }
+
+    func testMaxLogsDiscardsOldestEntries() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs", maxLogs: 100)
+
+        for index in 0..<1000 {
+            logBird.log("log-\(index)")
+        }
+
+        let logs = waitForLogs(of: logBird, count: 100)
+        XCTAssertEqual(logs.count, 100)
+        XCTAssertEqual(logs.first?.message, "log-999")
+        XCTAssertEqual(logs.last?.message, "log-900")
+    }
+
+    func testMaxLogsSetterTrimsExistingHistory() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-setter")
+
+        for index in 0..<50 {
+            logBird.log("log-\(index)")
+        }
+        XCTAssertEqual(waitForLogs(of: logBird, count: 50).count, 50)
+
+        let expectation = expectation(description: "history is trimmed")
+        var latest: [LBLog] = []
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if logs.count == 10 {
+                expectation.fulfill()
+            }
+        }
+
+        logBird.maxLogs = 10
+
+        wait(for: [expectation], timeout: 5)
+        cancellable.cancel()
+        XCTAssertEqual(latest.count, 10)
+        XCTAssertEqual(latest.first?.message, "log-49")
+        XCTAssertEqual(latest.last?.message, "log-40")
+    }
+
+    func testLogWithoutMessage() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "no-message")
+
+        logBird.log(level: .error)
+
+        let logs = waitForLogs(of: logBird, count: 1)
+        XCTAssertNil(logs.first?.message)
+        XCTAssertEqual(logs.first?.level, .error)
+    }
+
+    func testLogPreservesAdditionalInfoTypes() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "additional-info")
+
+        logBird.log("typed", additionalInfo: [
+            "count": .int(12),
+            "ratio": .double(1.5),
+            "flag": .bool(true),
+            "name": .string("twelve"),
+            "site": .url(URL(string: "https://example.com")!)
+        ])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["count"], .int(12))
+        XCTAssertEqual(info?["ratio"], .double(1.5))
+        XCTAssertEqual(info?["flag"], .bool(true))
+        XCTAssertEqual(info?["name"], .string("twelve"))
+        XCTAssertEqual(info?["site"], .url(URL(string: "https://example.com")!))
+    }
+
+    func testDecodingErrorKeepsContextAndType() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "decoding-error")
+        let json = Data(#"{"count": "not-a-number"}"#.utf8)
+
+        do {
+            _ = try JSONDecoder().decode([String: Int].self, from: json)
+            XCTFail("Decoding should fail")
+        } catch {
+            logBird.log(error: error, level: .error)
+        }
+
+        let error = waitForLogs(of: logBird, count: 1).first?.error
+        XCTAssertEqual(error?.type, "DecodingError")
+        XCTAssertEqual(error?.userInfo?["codingPath"], "count")
+        XCTAssertNotNil(error?.userInfo?["debugDescription"])
+    }
+
+    func testNSErrorUserInfoProducesReadableStrings() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "nserror")
+        let underlying = NSError(domain: "com.test.inner", code: 42, userInfo: [NSLocalizedDescriptionKey: "inner failure"])
+        let error = NSError(domain: "com.test.outer", code: 7, userInfo: [
+            NSUnderlyingErrorKey: underlying,
+            "object": NSObject(),
+            "retries": 3
+        ])
+
+        logBird.log(error: error, level: .error)
+
+        let lbError = waitForLogs(of: logBird, count: 1).first?.error
+        XCTAssertEqual(lbError?.type, "NSError")
+        XCTAssertEqual(lbError?.domain, "com.test.outer")
+        XCTAssertEqual(lbError?.code, 7)
+        XCTAssertEqual(lbError?.userInfo?["NSUnderlyingError"], "com.test.inner (42): inner failure")
+        XCTAssertEqual(lbError?.userInfo?["object"], "<non-string>")
+        XCTAssertEqual(lbError?.userInfo?["retries"], "3")
+    }
+
+    func testExportJSONProducesDecodableArray() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-json")
+
+        for index in 0..<5 {
+            logBird.log("export-\(index)")
+        }
+
+        let decoded = try JSONDecoder().decode([LBLog].self, from: logBird.exportLogs(format: .json))
+        XCTAssertEqual(decoded.count, 5)
+    }
+
+    func testExportJSONLinesProducesOneObjectPerLine() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-jsonlines")
+
+        for index in 0..<5 {
+            logBird.log("export-\(index)")
+        }
+
+        let text = String(decoding: logBird.exportLogs(format: .jsonLines), as: UTF8.self)
+        let lines = text.split(separator: "\n")
+        XCTAssertEqual(lines.count, 5)
+
+        for line in lines {
+            XCTAssertNoThrow(try JSONDecoder().decode(LBLog.self, from: Data(line.utf8)))
+        }
+    }
+
+    func testExportPlainTextContainsFormattedMessages() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-plaintext")
+
+        logBird.log("plain-text-marker", level: .warning)
+
+        let text = String(decoding: logBird.exportLogs(format: .plainText), as: UTF8.self)
+        XCTAssertTrue(text.contains("plain-text-marker"))
+        XCTAssertTrue(text.contains("LogBird:"))
+        XCTAssertTrue(text.contains("WARNING"))
+    }
+
+    func testWriteLogsWritesFile() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "write-logs")
+        logBird.log("written")
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logbird-test-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try logBird.writeLogs(to: url, format: .json)
+
+        let decoded = try JSONDecoder().decode([LBLog].self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.message, "written")
+    }
+}

--- a/Tests/LogBirdTests/LBManagerTests.swift
+++ b/Tests/LogBirdTests/LBManagerTests.swift
@@ -24,14 +24,28 @@ final class LBManagerTests: XCTestCase {
     func testMaxLogsDiscardsOldestEntries() {
         let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs", maxLogs: 100)
 
+        // The terminal snapshot has the newest entry first; waiting for it avoids
+        // asserting on an intermediate trimmed emission.
+        let expectation = expectation(description: "history settles at the cap")
+        var latest: [LBLog] = []
+        var fulfilled = false
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if !fulfilled, logs.count == 100, logs.first?.message == "log-999" {
+                fulfilled = true
+                expectation.fulfill()
+            }
+        }
+
         for index in 0..<1000 {
             logBird.log("log-\(index)")
         }
 
-        let logs = waitForLogs(of: logBird, count: 100)
-        XCTAssertEqual(logs.count, 100)
-        XCTAssertEqual(logs.first?.message, "log-999")
-        XCTAssertEqual(logs.last?.message, "log-900")
+        wait(for: [expectation], timeout: 5)
+        cancellable.cancel()
+        XCTAssertEqual(latest.count, 100)
+        XCTAssertEqual(latest.first?.message, "log-999")
+        XCTAssertEqual(latest.last?.message, "log-900")
     }
 
     func testMaxLogsSetterTrimsExistingHistory() {
@@ -44,9 +58,11 @@ final class LBManagerTests: XCTestCase {
 
         let expectation = expectation(description: "history is trimmed")
         var latest: [LBLog] = []
+        var fulfilled = false
         let cancellable = logBird.logsPublisher.sink { logs in
             latest = logs
-            if logs.count == 10 {
+            if !fulfilled, logs.count == 10 {
+                fulfilled = true
                 expectation.fulfill()
             }
         }
@@ -58,6 +74,32 @@ final class LBManagerTests: XCTestCase {
         XCTAssertEqual(latest.count, 10)
         XCTAssertEqual(latest.first?.message, "log-49")
         XCTAssertEqual(latest.last?.message, "log-40")
+    }
+
+    func testMaxLogsBelowOneIsClamped() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-clamp", maxLogs: 0)
+        XCTAssertEqual(logBird.maxLogs, 1)
+
+        logBird.maxLogs = -5
+        XCTAssertEqual(logBird.maxLogs, 1)
+
+        let expectation = expectation(description: "newest entry is retained")
+        var latest: [LBLog] = []
+        var fulfilled = false
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if !fulfilled, logs.first?.message == "second" {
+                fulfilled = true
+                expectation.fulfill()
+            }
+        }
+
+        logBird.log("first")
+        logBird.log("second")
+
+        wait(for: [expectation], timeout: 5)
+        cancellable.cancel()
+        XCTAssertEqual(latest.count, 1)
     }
 
     func testLogWithoutMessage() {
@@ -104,6 +146,24 @@ final class LBManagerTests: XCTestCase {
         XCTAssertEqual(error?.type, "DecodingError")
         XCTAssertEqual(error?.userInfo?["codingPath"], "count")
         XCTAssertNotNil(error?.userInfo?["debugDescription"])
+        XCTAssertNil(error?.userInfo?["NSCodingPath"])
+        XCTAssertNil(error?.userInfo?["NSDebugDescription"])
+    }
+
+    func testEncodingErrorKeepsContextAndType() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "encoding-error")
+
+        do {
+            _ = try JSONEncoder().encode(["ratio": Double.nan])
+            XCTFail("Encoding should fail")
+        } catch {
+            logBird.log(error: error, level: .error)
+        }
+
+        let error = waitForLogs(of: logBird, count: 1).first?.error
+        XCTAssertEqual(error?.type, "EncodingError")
+        XCTAssertEqual(error?.userInfo?["codingPath"], "ratio")
+        XCTAssertNotNil(error?.userInfo?["debugDescription"])
     }
 
     func testNSErrorUserInfoProducesReadableStrings() {
@@ -112,7 +172,10 @@ final class LBManagerTests: XCTestCase {
         let error = NSError(domain: "com.test.outer", code: 7, userInfo: [
             NSUnderlyingErrorKey: underlying,
             "object": NSObject(),
-            "retries": 3
+            "null": NSNull(),
+            "retries": 3,
+            "flag": true,
+            "site": URL(string: "https://example.com")!
         ])
 
         logBird.log(error: error, level: .error)
@@ -123,7 +186,10 @@ final class LBManagerTests: XCTestCase {
         XCTAssertEqual(lbError?.code, 7)
         XCTAssertEqual(lbError?.userInfo?["NSUnderlyingError"], "com.test.inner (42): inner failure")
         XCTAssertEqual(lbError?.userInfo?["object"], "<non-string>")
+        XCTAssertEqual(lbError?.userInfo?["null"], "<null>")
         XCTAssertEqual(lbError?.userInfo?["retries"], "3")
+        XCTAssertEqual(lbError?.userInfo?["flag"], "true")
+        XCTAssertEqual(lbError?.userInfo?["site"], "https://example.com")
     }
 
     func testExportJSONProducesDecodableArray() throws {
@@ -144,7 +210,9 @@ final class LBManagerTests: XCTestCase {
             logBird.log("export-\(index)")
         }
 
-        let text = String(decoding: logBird.exportLogs(format: .jsonLines), as: UTF8.self)
+        let text = String(decoding: try logBird.exportLogs(format: .jsonLines), as: UTF8.self)
+        XCTAssertTrue(text.hasSuffix("\n"))
+
         let lines = text.split(separator: "\n")
         XCTAssertEqual(lines.count, 5)
 
@@ -153,15 +221,43 @@ final class LBManagerTests: XCTestCase {
         }
     }
 
-    func testExportPlainTextContainsFormattedMessages() {
+    func testExportPlainTextContainsFormattedMessages() throws {
         let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-plaintext")
 
         logBird.log("plain-text-marker", level: .warning)
 
-        let text = String(decoding: logBird.exportLogs(format: .plainText), as: UTF8.self)
+        let text = String(decoding: try logBird.exportLogs(format: .plainText), as: UTF8.self)
         XCTAssertTrue(text.contains("plain-text-marker"))
         XCTAssertTrue(text.contains("LogBird:"))
         XCTAssertTrue(text.contains("WARNING"))
+    }
+
+    func testExportPlainTextIncludesIdentifier() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-identifier")
+        logBird.setIdentifier("session-42")
+
+        logBird.log("identified")
+
+        let text = String(decoding: try logBird.exportLogs(format: .plainText), as: UTF8.self)
+        XCTAssertTrue(text.contains("session-42"))
+    }
+
+    func testExportEmptyHistory() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-empty")
+
+        let json = try logBird.exportLogs(format: .json)
+        XCTAssertEqual(try JSONDecoder().decode([LBLog].self, from: json).count, 0)
+
+        XCTAssertTrue(try logBird.exportLogs(format: .jsonLines).isEmpty)
+        XCTAssertTrue(try logBird.exportLogs(format: .plainText).isEmpty)
+    }
+
+    func testExportThrowsOnNonFiniteDouble() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "export-nan")
+        logBird.log("nan", additionalInfo: ["ratio": .double(.nan)])
+
+        XCTAssertThrowsError(try logBird.exportLogs(format: .json))
+        XCTAssertThrowsError(try logBird.exportLogs(format: .jsonLines))
     }
 
     func testWriteLogsWritesFile() throws {

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -59,7 +59,7 @@ final class LogsViewModelTests: XCTestCase {
             makeLog(message: "exported", level: .warning)
         ]
 
-        let data = viewModel.exportData()
+        let data = try XCTUnwrap(viewModel.exportData())
         let decoded = try JSONDecoder().decode([LBLog].self, from: data)
 
         XCTAssertEqual(decoded.count, 1)

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -59,7 +59,7 @@ final class LogsViewModelTests: XCTestCase {
             makeLog(message: "exported", level: .warning)
         ]
 
-        let data = try XCTUnwrap(viewModel.exportData())
+        let data = viewModel.exportData()
         let decoded = try JSONDecoder().decode([LBLog].self, from: data)
 
         XCTAssertEqual(decoded.count, 1)


### PR DESCRIPTION
## Summary

A batch of logging-core improvements that harden the in-memory history, make metadata type-safe end to end, and turn log export into a public API with multiple formats.

### History
- The in-memory history is now capped by a configurable `maxLogs` (default 1000). Once the limit is reached, the oldest entries are discarded and the trimmed snapshot is published. Available per instance and on `LogBird.shared`.

### Typed metadata — **breaking**
- `additionalInfo` changed from `[String: Any]` to `[String: LBValue]`. `LBValue` (`.string`, `.int`, `.double`, `.bool`, `.url`) keeps the original type when logs are encoded to JSON instead of stringifying everything. String, integer, float and boolean literals convert implicitly, so existing call sites like `["userId": 12]` keep compiling unchanged.
- Decoding is best-effort and documented: URLs decode as `.string` and whole-number doubles as `.int` (JSON carries no distinct types for them).

### Errors
- `LBError` gains a `type` field with the Swift type of the original error.
- `DecodingError` and `EncodingError` now contribute their context (coding path, debug description, missing key, underlying error) to `userInfo` instead of falling back to a generic bridged description, replacing the poorly stringified `NSCodingPath`/`NSDebugDescription` keys.
- `userInfo` values are rendered readably: nested errors as `domain (code): description`, booleans as `true`/`false`, URLs as absolute strings, and objects without a meaningful description as `<non-string>` instead of `<ClassName: 0x...>`.

### API refinements — **breaking**
- `log(_:)` accepts an optional `message`, so error-only or metadata-only entries no longer need a placeholder string.
- `LBLog.prettyJSON()` is now `throws` and returns a non-optional `String`, using a shared encoder with sorted keys for deterministic output. The `print` on encoding failure is gone.
- The initializers of `LBLog`, `LBSource`, `LBLocation` and `LBError` are internal: entries are created by the logging pipeline, which captures the timestamp, call-site location and source. `LBExtraMessage` stays public as an input payload.
- `LBLogRowView` is no longer public; it is an implementation detail of `LBLogsView`.

### Export
- New `LBExportFormat` (`.json`, `.jsonLines`, `.plainText`) with `LogBird.exportLogs(format:) throws -> Data` and `LogBird.writeLogs(to:format:)`, both per instance and on `shared`. Encoding failures (e.g. a non-finite double) surface as thrown errors instead of silently empty data.
- The logs view export menu offers all three formats and writes files with the matching extension and content type; it still exports the currently filtered logs, including the session identifier in plain-text output.
- Formatted output sorts `additionalInfo` and `userInfo` keys, so plain-text exports are deterministic; JSON Lines files end with a trailing newline.

### Model refinements
- `LBLog`, `LBSource`, `LBLocation`, `LBError` and `LBExtraMessage` are `Hashable` and `Sendable`; `LBLog` equality includes `id` so only the same recorded entry compares equal.
- `LBExtraMessage` is `Identifiable` (unique per instance, content-based equality), fixing `ForEach` diffing for duplicate extra messages.
- `LBLogLevel` conforms to `CustomStringConvertible`.

### Behavior changes
- Log timestamps use an ISO8601 date style with fractional seconds and an explicit time zone offset, independent of the user's locale.
- OSLog messages are emitted with `privacy: .public` so they stay readable in release builds and Console.app.

## Test plan
- 35 unit tests pass locally (`swift test`), covering history trimming and clamping, typed metadata, error context, userInfo rendering, every export format (including empty history and encoding failures), and deterministic JSON output.
- `pod lib lint` passes for iOS and macOS.
