### PR TITLE
Fix flaky expectations in LogBirdTests

### DIFF
--- a/Tests/LogBirdTests/LogBirdTests.swift
+++ b/Tests/LogBirdTests/LogBirdTests.swift
@@ -17,9 +17,11 @@ final class LogBirdTests: XCTestCase {
     private func waitForLogs(of logBird: LogBird, count expectedCount: Int, timeout: TimeInterval = 5) -> [LBLog] {
         let expectation = expectation(description: "logs reach \(expectedCount)")
         var latest: [LBLog] = []
+        var fulfilled = false
         let cancellable = logBird.logsPublisher.sink { logs in
             latest = logs
-            if logs.count >= expectedCount {
+            if !fulfilled, logs.count >= expectedCount {
+                fulfilled = true
                 expectation.fulfill()
             }
         }
@@ -70,11 +72,19 @@ final class LogBirdTests: XCTestCase {
         logBird.log("second")
         XCTAssertEqual(waitForLogs(of: logBird, count: 2).count, 2)
 
+        // The subject replays its current value on subscription, which can be an
+        // empty snapshot; only fulfill once a non-empty history has been cleared.
         let expectation = expectation(description: "logs are cleared")
         var latest: [LBLog]? = nil
+        var sawLogs = false
+        var fulfilled = false
         let cancellable = logBird.logsPublisher.sink { logs in
+            if !logs.isEmpty {
+                sawLogs = true
+            }
             latest = logs
-            if logs.isEmpty {
+            if !fulfilled, sawLogs, logs.isEmpty {
+                fulfilled = true
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
## Summary

The post-merge CI run on `release/2.0.0` failed with `API violation - multiple calls made to -[XCTestExpectation fulfill]` in `testClearLogsEmptiesHistory`. Two sinks in this file could fulfill more than once:

- `waitForLogs`: every emission at or above the expected count fulfilled again until the cancellable was cancelled.
- `testClearLogsEmptiesHistory`: the `CurrentValueSubject` replays its current value on subscription, so the initial (possibly empty) snapshot fulfilled the expectation, and the post-clear empty snapshot fulfilled it again. The replay also meant the test could pass without a clear ever happening.

Both sinks now fulfill at most once, and the clear test only accepts an empty snapshot that follows a non-empty one.

## Test plan
- `swift test` run 5 times locally: 35/35 pass each time.