### PR TITLE
Add message privacy interpolation and sensitive-field redaction

### DIFF
--- a/Sources/LogBird/LBLogMessage.swift
+++ b/Sources/LogBird/LBLogMessage.swift
@@ -1,0 +1,71 @@
+//
+//  LBLogMessage.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 29/07/2026.
+//
+
+import Foundation
+
+/// Privacy level of an interpolated value in an `LBLogMessage`.
+public enum LBPrivacy: Sendable {
+    /// The value is rendered as-is.
+    case `public`
+    /// The value is replaced by a placeholder while the message is built.
+    case `private`
+}
+
+/// A log message built through string interpolation with per-value privacy.
+///
+/// Interpolated values are public by default. Mark sensitive values with
+/// `privacy: .private` and they are replaced by `<redacted>` while the message
+/// is being built, so the original value never reaches the stored log, OSLog,
+/// or any exported output:
+///
+///     logBird.log("User \(username, privacy: .private) logged in")
+///     // Stored as: "User <redacted> logged in"
+public struct LBLogMessage: ExpressibleByStringInterpolation, Hashable, Sendable {
+
+    /// The message with every private interpolation already replaced by the placeholder.
+    public let value: String
+
+    public init(stringInterpolation: StringInterpolation) {
+        value = stringInterpolation.output
+    }
+
+    public init(stringLiteral value: String) {
+        self.value = value
+    }
+}
+
+extension LBLogMessage: CustomStringConvertible {
+    public var description: String { value }
+}
+
+extension LBLogMessage {
+    public struct StringInterpolation: StringInterpolationProtocol {
+        var output: String
+
+        public init(literalCapacity: Int, interpolationCount: Int) {
+            output = String()
+            output.reserveCapacity(literalCapacity)
+        }
+
+        public mutating func appendLiteral(_ literal: String) {
+            output.append(literal)
+        }
+
+        public mutating func appendInterpolation<T>(_ value: T) {
+            output.append(String(describing: value))
+        }
+
+        public mutating func appendInterpolation<T>(_ value: T, privacy: LBPrivacy) {
+            switch privacy {
+            case .public:
+                output.append(String(describing: value))
+            case .private:
+                output.append(LBRedactor.placeholder)
+            }
+        }
+    }
+}

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -33,6 +33,8 @@ final class LBManager: @unchecked Sendable {
     }()
 
     private var storedMaxLogs: Int
+    private var storedRedactSensitiveFields: Bool = true
+    private var storedSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
 
     /// The maximum number of entries kept in memory. Once the limit is reached,
     /// the oldest entries are discarded. Values below 1 are treated as 1.
@@ -57,6 +59,19 @@ final class LBManager: @unchecked Sendable {
         dispatchQueue.sync { identifier }
     }
 
+    /// Whether values under sensitive keys are redacted before a log is stored.
+    var redactSensitiveFields: Bool {
+        get { dispatchQueue.sync { storedRedactSensitiveFields } }
+        set { dispatchQueue.sync { storedRedactSensitiveFields = newValue } }
+    }
+
+    /// The keys considered sensitive when redacting. See `LBRedactor` for the
+    /// matching rules.
+    var sensitiveKeys: [String] {
+        get { dispatchQueue.sync { storedSensitiveKeys } }
+        set { dispatchQueue.sync { storedSensitiveKeys = newValue } }
+    }
+
     init(subsystem: String, category: String, maxLogs: Int = 1000) {
         let source = LBSource(subsystem: subsystem, category: category)
         self.logger = Logger(subsystem: source.subsystem, category: source.category)
@@ -79,6 +94,11 @@ final class LBManager: @unchecked Sendable {
              function: String = #function,
              line: Int = #line) {
 
+        // Snapshot the redaction config so `buildLogData` stays off the state queue.
+        let redactor = dispatchQueue.sync {
+            LBRedactor(isEnabled: self.storedRedactSensitiveFields, sensitiveKeys: self.storedSensitiveKeys)
+        }
+
         // `buildLogData` only reads immutable `source` and the supplied parameters.
         let log = buildLogData(message: message,
                                extraMessages: extraMessages,
@@ -87,7 +107,8 @@ final class LBManager: @unchecked Sendable {
                                level: level,
                                file: file,
                                function: function,
-                               line: line)
+                               line: line,
+                               redactor: redactor)
 
         // Serialize identifier read and log mutation to keep state consistent.
         dispatchQueue.sync {
@@ -130,15 +151,16 @@ final class LBManager: @unchecked Sendable {
                               level: LBLogLevel,
                               file: String,
                               function: String,
-                              line: Int) -> LBLog {
+                              line: Int,
+                              redactor: LBRedactor) -> LBLog {
 
-        let errorData: LBError? = errorToLBError(error) ?? nil
+        let errorData: LBError? = errorToLBError(error, redactor: redactor) ?? nil
 
         let log = LBLog(
             level: level,
             message: message,
             extraMessages: extraMessages,
-            additionalInfo: additionalInfo,
+            additionalInfo: redactor.redact(additionalInfo),
             error: errorData,
             createdAt: Date().timeIntervalSince1970,
             location: LBLocation(file: file, function: function, line: line),
@@ -148,7 +170,7 @@ final class LBManager: @unchecked Sendable {
         return log
     }
 
-    private func errorToLBError(_ error: Error?) -> LBError? {
+    private func errorToLBError(_ error: Error?, redactor: LBRedactor) -> LBError? {
         guard let error else { return nil }
         let nsError = error as NSError
 
@@ -172,7 +194,7 @@ final class LBManager: @unchecked Sendable {
             code: nsError.code,
             type: String(describing: Swift.type(of: error)),
             localizedDescription: nsError.localizedDescription,
-            userInfo: userInfoString
+            userInfo: redactor.redact(userInfoString)
         )
     }
 

--- a/Sources/LogBird/LBRedactor.swift
+++ b/Sources/LogBird/LBRedactor.swift
@@ -1,0 +1,51 @@
+//
+//  LBRedactor.swift
+//  LogBird
+//
+//  Created by Javier Manzo on 29/07/2026.
+//
+
+import Foundation
+
+/// Replaces values under sensitive keys with a fixed placeholder.
+///
+/// A key is sensitive when it contains any of the configured keys; matching is
+/// case-insensitive and applies to both sides, so `accessToken` and
+/// `AUTH_TOKEN` both match `token`.
+struct LBRedactor: Sendable {
+
+    static let placeholder = "<redacted>"
+
+    static let defaultSensitiveKeys = ["password", "token", "authorization", "secret", "apiKey", "cookie"]
+
+    let isEnabled: Bool
+    private let needles: [String]
+
+    init(isEnabled: Bool, sensitiveKeys: [String]) {
+        self.isEnabled = isEnabled
+        self.needles = sensitiveKeys.map { $0.lowercased() }
+    }
+
+    func redact(_ info: [String: LBValue]?) -> [String: LBValue]? {
+        guard let info, isEnabled else { return info }
+        var redacted = info
+        for key in info.keys where isSensitive(key) {
+            redacted[key] = .string(Self.placeholder)
+        }
+        return redacted
+    }
+
+    func redact(_ userInfo: [String: String]?) -> [String: String]? {
+        guard let userInfo, isEnabled else { return userInfo }
+        var redacted = userInfo
+        for key in userInfo.keys where isSensitive(key) {
+            redacted[key] = Self.placeholder
+        }
+        return redacted
+    }
+
+    private func isSensitive(_ key: String) -> Bool {
+        let key = key.lowercased()
+        return needles.contains { key.contains($0) }
+    }
+}

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -58,6 +58,10 @@ extension LogBird {
         shared.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
+    static public func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+        shared.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
+    }
+
     static public func clearLogs() {
         shared.clearLogs()
     }
@@ -108,6 +112,10 @@ extension LogBird {
 
     public func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         manager.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
+    }
+
+    public func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+        manager.log(message.value, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
     public func clearLogs() {

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -31,6 +31,25 @@ extension LogBird {
         set { shared.maxLogs = newValue }
     }
 
+    /// Keys matched by default when redacting sensitive fields.
+    static public let defaultSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
+
+    /// Whether values under sensitive keys in `additionalInfo` and
+    /// `error.userInfo` are replaced by `<redacted>` before a log is stored.
+    /// Default: `true`.
+    static public var redactSensitiveFields: Bool {
+        get { shared.redactSensitiveFields }
+        set { shared.redactSensitiveFields = newValue }
+    }
+
+    /// The keys considered sensitive when redacting. A key is sensitive when it
+    /// contains any of these values; matching is case-insensitive, so
+    /// `accessToken` matches `token`.
+    static public var sensitiveKeys: [String] {
+        get { shared.sensitiveKeys }
+        set { shared.sensitiveKeys = newValue }
+    }
+
     static public func setIdentifier(_ identifier: String?) {
         shared.setIdentifier(identifier)
     }
@@ -65,6 +84,22 @@ extension LogBird {
     public var maxLogs: Int {
         get { manager.maxLogs }
         set { manager.maxLogs = newValue }
+    }
+
+    /// Whether values under sensitive keys in `additionalInfo` and
+    /// `error.userInfo` are replaced by `<redacted>` before a log is stored.
+    /// Default: `true`.
+    public var redactSensitiveFields: Bool {
+        get { manager.redactSensitiveFields }
+        set { manager.redactSensitiveFields = newValue }
+    }
+
+    /// The keys considered sensitive when redacting. A key is sensitive when it
+    /// contains any of these values; matching is case-insensitive, so
+    /// `accessToken` matches `token`.
+    public var sensitiveKeys: [String] {
+        get { manager.sensitiveKeys }
+        set { manager.sensitiveKeys = newValue }
     }
 
     public func setIdentifier(_ value: String?) {

--- a/Tests/LogBirdTests/LBLogMessageTests.swift
+++ b/Tests/LogBirdTests/LBLogMessageTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import LogBird
+
+final class LBLogMessageTests: XCTestCase {
+
+    /// Waits until `logsPublisher` reports at least `expectedCount` entries and
+    /// returns the latest snapshot.
+    private func waitForLogs(of logBird: LogBird, count expectedCount: Int, timeout: TimeInterval = 5) -> [LBLog] {
+        let expectation = expectation(description: "logs reach \(expectedCount)")
+        var latest: [LBLog] = []
+        var fulfilled = false
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if !fulfilled, logs.count >= expectedCount {
+                fulfilled = true
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: timeout)
+        cancellable.cancel()
+        return latest
+    }
+
+    func testPlainLiteralKeepsContent() {
+        let message: LBLogMessage = "User logged in"
+        XCTAssertEqual(message.value, "User logged in")
+    }
+
+    func testInterpolationIsPublicByDefault() {
+        let attempts = 3
+        let message: LBLogMessage = "Retrying (attempt \(attempts))"
+        XCTAssertEqual(message.value, "Retrying (attempt 3)")
+    }
+
+    func testPrivateInterpolationIsRedacted() {
+        let username = "javier.manzo"
+        let message: LBLogMessage = "User \(username, privacy: .private) logged in"
+        XCTAssertEqual(message.value, "User <redacted> logged in")
+    }
+
+    func testMixedPrivacyInterpolations() {
+        let username = "javier"
+        let ip = "192.168.1.10"
+        let message: LBLogMessage = "User \(username, privacy: .private) connected from \(ip, privacy: .public)"
+        XCTAssertEqual(message.value, "User <redacted> connected from 192.168.1.10")
+    }
+
+    func testPrivateInterpolationRedactsNonStringValues() {
+        let userID = 42
+        let message: LBLogMessage = "User id: \(userID, privacy: .private)"
+        XCTAssertEqual(message.value, "User id: <redacted>")
+    }
+
+    func testDescriptionMatchesValue() {
+        let message: LBLogMessage = "Hello \("world")"
+        XCTAssertEqual(message.description, "Hello world")
+    }
+
+    func testLoggedMessageIsStoredRedacted() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "privacy-message")
+        let token = "secret-token"
+
+        logBird.log("auth with \(token, privacy: .private)")
+
+        XCTAssertEqual(waitForLogs(of: logBird, count: 1).first?.message, "auth with <redacted>")
+    }
+
+    func testExportDoesNotContainPrivateInterpolation() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "privacy-export")
+        let token = "secret-token"
+
+        logBird.log("auth with \(token, privacy: .private)")
+
+        let json = String(decoding: try logBird.exportLogs(format: .json), as: UTF8.self)
+        XCTAssertFalse(json.contains(token))
+        XCTAssertTrue(json.contains("<redacted>"))
+    }
+}

--- a/Tests/LogBirdTests/LBRedactionTests.swift
+++ b/Tests/LogBirdTests/LBRedactionTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import LogBird
+
+final class LBRedactionTests: XCTestCase {
+
+    /// Waits until `logsPublisher` reports at least `expectedCount` entries and
+    /// returns the latest snapshot.
+    private func waitForLogs(of logBird: LogBird, count expectedCount: Int, timeout: TimeInterval = 5) -> [LBLog] {
+        let expectation = expectation(description: "logs reach \(expectedCount)")
+        var latest: [LBLog] = []
+        var fulfilled = false
+        let cancellable = logBird.logsPublisher.sink { logs in
+            latest = logs
+            if !fulfilled, logs.count >= expectedCount {
+                fulfilled = true
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: timeout)
+        cancellable.cancel()
+        return latest
+    }
+
+    func testAdditionalInfoRedactsDefaultKeys() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-defaults")
+
+        logBird.log("login", additionalInfo: [
+            "username": .string("javier"),
+            "password": .string("123456"),
+            "Authorization": .string("Bearer abc123"),
+            "retries": .int(2)
+        ])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["username"], .string("javier"))
+        XCTAssertEqual(info?["password"], .string("<redacted>"))
+        XCTAssertEqual(info?["Authorization"], .string("<redacted>"))
+        XCTAssertEqual(info?["retries"], .int(2))
+    }
+
+    func testSensitiveKeyMatchingIsCaseInsensitiveSubstring() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-matching")
+
+        logBird.log("matching", additionalInfo: [
+            "accessToken": .string("a"),
+            "AUTH_TOKEN": .string("b"),
+            "apiKey": .string("c"),
+            "mySecret": .string("d"),
+            "sessionId": .string("e")
+        ])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["accessToken"], .string("<redacted>"))
+        XCTAssertEqual(info?["AUTH_TOKEN"], .string("<redacted>"))
+        XCTAssertEqual(info?["apiKey"], .string("<redacted>"))
+        XCTAssertEqual(info?["mySecret"], .string("<redacted>"))
+        XCTAssertEqual(info?["sessionId"], .string("e"))
+    }
+
+    func testRedactedValueBecomesStringRegardlessOfOriginalType() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-type")
+
+        logBird.log("typed", additionalInfo: ["token": .int(12345)])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["token"], .string("<redacted>"))
+    }
+
+    func testRedactionCanBeDisabled() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-disabled")
+        logBird.redactSensitiveFields = false
+
+        logBird.log("raw", additionalInfo: ["token": .string("abc123")])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["token"], .string("abc123"))
+    }
+
+    func testCustomSensitiveKeysReplaceDefaults() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-custom")
+        logBird.sensitiveKeys = ["session"]
+
+        logBird.log("custom", additionalInfo: [
+            "sessionId": .string("xyz"),
+            "token": .string("abc123")
+        ])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["sessionId"], .string("<redacted>"))
+        XCTAssertEqual(info?["token"], .string("abc123"))
+    }
+
+    func testRedactionConfigIsPerInstance() {
+        let first = LogBird(subsystem: "com.logbird.tests", category: "redaction-first")
+        let second = LogBird(subsystem: "com.logbird.tests", category: "redaction-second")
+
+        first.redactSensitiveFields = false
+
+        XCTAssertFalse(first.redactSensitiveFields)
+        XCTAssertTrue(second.redactSensitiveFields)
+        XCTAssertEqual(second.sensitiveKeys, LogBird.defaultSensitiveKeys)
+    }
+
+    func testErrorUserInfoIsRedacted() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-error")
+        let error = NSError(domain: "com.test.networking", code: 401, userInfo: [
+            "Authorization": "Bearer abc123",
+            "url": "https://api.example.com/login"
+        ])
+
+        logBird.log("request failed", error: error, level: .error)
+
+        let userInfo = waitForLogs(of: logBird, count: 1).first?.error?.userInfo
+        XCTAssertEqual(userInfo?["Authorization"], "<redacted>")
+        XCTAssertEqual(userInfo?["url"], "https://api.example.com/login")
+    }
+
+    func testExportDoesNotLeakSensitiveValues() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-export")
+        let error = NSError(domain: "com.test", code: 1, userInfo: ["secret": "shhh"])
+
+        logBird.log("auth", additionalInfo: ["token": .string("Bearer abc123")], error: error)
+
+        let json = String(decoding: try logBird.exportLogs(format: .json), as: UTF8.self)
+        XCTAssertFalse(json.contains("Bearer abc123"))
+        XCTAssertFalse(json.contains("shhh"))
+        XCTAssertTrue(json.contains("<redacted>"))
+    }
+
+    func testDefaultKeysIncludePasswordAndAuthorization() {
+        XCTAssertTrue(LogBird.defaultSensitiveKeys.contains("password"))
+        XCTAssertTrue(LogBird.defaultSensitiveKeys.contains("authorization"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds two complementary privacy mechanisms so sensitive data never reaches the log pipeline (memory history, OSLog, Combine publisher, in-app viewer, or exports).

**Privacy-aware message interpolation** — a new `LBLogMessage` type with OSLog-style interpolation. Interpolated values are public by default; marking one with `privacy: .private` replaces it with `<redacted>` while the message is being built:

```swift
logBird.log("User \(username, privacy: .private) logged in")
// Stored as: "User <redacted> logged in"
```

Existing `log(_ message: String?)` calls are unaffected: plain literals still resolve to the `String` overload.

**Sensitive-field redaction** — values under sensitive keys in `additionalInfo` and `error.userInfo` are replaced by `<redacted>` before a log is stored. A key is sensitive when it contains any configured key (case-insensitive), so `accessToken` matches `token`.

- `redactSensitiveFields: Bool` (default `true`)
- `sensitiveKeys: [String]` (defaults: `password`, `token`, `authorization`, `secret`, `apiKey`, `cookie`), plus `LogBird.defaultSensitiveKeys`
- Configurable per instance and via `LogBird.shared`

This covers data the caller cannot mark by hand, such as an `NSError.userInfo` coming from another layer or library.

## Behavior change

Redaction is ON by default: values under matching keys are now stored as `<redacted>`, and a redacted value is always stored as a string. Set `redactSensitiveFields = false` or adjust `sensitiveKeys` to opt out.

## Tests

- Interpolation: plain literals, default-public values, private/mixed/non-string interpolations, stored and exported output.
- Redaction: default keys, case-insensitive substring matching, disabled flag, custom keys, per-instance config, `error.userInfo`, and export leak checks.