### PR TITLE
Document redaction semantics and harden redaction tests

### DIFF
--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -34,9 +34,17 @@ extension LogBird {
     /// Keys matched by default when redacting sensitive fields.
     static public let defaultSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
 
+    /// The string that replaces a redacted value.
+    static public let redactionPlaceholder: String = LBRedactor.placeholder
+
     /// Whether values under sensitive keys in `additionalInfo` and
-    /// `error.userInfo` are replaced by `<redacted>` before a log is stored.
-    /// Default: `true`.
+    /// `error.userInfo` are replaced by the redaction placeholder before a log
+    /// is stored. Default: `true`.
+    ///
+    /// A redacted value is always stored as a string, regardless of its
+    /// original type. Free-text fields (`message`, `extraMessages`, and an
+    /// error's `localizedDescription`) are not scanned; mark sensitive values
+    /// at the call site with `LBLogMessage` instead.
     static public var redactSensitiveFields: Bool {
         get { shared.redactSensitiveFields }
         set { shared.redactSensitiveFields = newValue }
@@ -45,6 +53,9 @@ extension LogBird {
     /// The keys considered sensitive when redacting. A key is sensitive when it
     /// contains any of these values; matching is case-insensitive, so
     /// `accessToken` matches `token`.
+    ///
+    /// Setting this property replaces the default keys; append to
+    /// `defaultSensitiveKeys` to extend them.
     static public var sensitiveKeys: [String] {
         get { shared.sensitiveKeys }
         set { shared.sensitiveKeys = newValue }
@@ -91,8 +102,13 @@ extension LogBird {
     }
 
     /// Whether values under sensitive keys in `additionalInfo` and
-    /// `error.userInfo` are replaced by `<redacted>` before a log is stored.
-    /// Default: `true`.
+    /// `error.userInfo` are replaced by the redaction placeholder before a log
+    /// is stored. Default: `true`.
+    ///
+    /// A redacted value is always stored as a string, regardless of its
+    /// original type. Free-text fields (`message`, `extraMessages`, and an
+    /// error's `localizedDescription`) are not scanned; mark sensitive values
+    /// at the call site with `LBLogMessage` instead.
     public var redactSensitiveFields: Bool {
         get { manager.redactSensitiveFields }
         set { manager.redactSensitiveFields = newValue }
@@ -101,6 +117,9 @@ extension LogBird {
     /// The keys considered sensitive when redacting. A key is sensitive when it
     /// contains any of these values; matching is case-insensitive, so
     /// `accessToken` matches `token`.
+    ///
+    /// Setting this property replaces the default keys; append to
+    /// `LogBird.defaultSensitiveKeys` to extend them.
     public var sensitiveKeys: [String] {
         get { manager.sensitiveKeys }
         set { manager.sensitiveKeys = newValue }

--- a/Tests/LogBirdTests/LBRedactionTests.swift
+++ b/Tests/LogBirdTests/LBRedactionTests.swift
@@ -96,9 +96,32 @@ final class LBRedactionTests: XCTestCase {
 
         first.redactSensitiveFields = false
 
-        XCTAssertFalse(first.redactSensitiveFields)
-        XCTAssertTrue(second.redactSensitiveFields)
+        first.log("raw", additionalInfo: ["token": .string("abc123")])
+        second.log("redacted", additionalInfo: ["token": .string("abc123")])
+
+        XCTAssertEqual(waitForLogs(of: first, count: 1).first?.additionalInfo?["token"], .string("abc123"))
+        XCTAssertEqual(waitForLogs(of: second, count: 1).first?.additionalInfo?["token"], .string("<redacted>"))
         XCTAssertEqual(second.sensitiveKeys, LogBird.defaultSensitiveKeys)
+    }
+
+    func testEmptySensitiveKeysRedactNothing() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-empty-keys")
+        logBird.sensitiveKeys = []
+
+        logBird.log("raw", additionalInfo: ["token": .string("abc123")])
+
+        let info = waitForLogs(of: logBird, count: 1).first?.additionalInfo
+        XCTAssertEqual(info?["token"], .string("abc123"))
+    }
+
+    func testPlainTextExportDoesNotLeakSensitiveValues() throws {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-plaintext")
+
+        logBird.log("auth", additionalInfo: ["token": .string("Bearer abc123")])
+
+        let text = String(decoding: try logBird.exportLogs(format: .plainText), as: UTF8.self)
+        XCTAssertFalse(text.contains("Bearer abc123"))
+        XCTAssertTrue(text.contains(LogBird.redactionPlaceholder))
     }
 
     func testErrorUserInfoIsRedacted() {


### PR DESCRIPTION
## Summary

Follow-up refinements to the redaction API:

- Expose `LogBird.redactionPlaceholder` so consumers can assert against the placeholder instead of hardcoding the literal.
- Document on `redactSensitiveFields`: redacted values are always stored as strings regardless of their original type, and free-text fields (`message`, `extraMessages`, an error's `localizedDescription`) are not scanned — sensitive values in message text should be marked at the call site with `LBLogMessage`.
- Document on `sensitiveKeys`: setting the property replaces the default keys; append to `defaultSensitiveKeys` to extend them.

## Tests

- `testRedactionConfigIsPerInstance` now logs the same sensitive value through both instances and asserts one redacts while the other does not.
- New: empty `sensitiveKeys` redacts nothing; plain-text export does not leak sensitive values.