### PR TITLE
Rename LBExtraMessage title/message to key/value

### DIFF
--- a/Example/LogBirdExample/LogBirdExampleApp.swift
+++ b/Example/LogBirdExample/LogBirdExampleApp.swift
@@ -15,7 +15,7 @@ struct LogBirdExampleApp: App {
         LogBird.clearLogs()
 
         let extraMessages: [LBExtraMessage] = [
-            LBExtraMessage(title: "Title Extra", message: "Message extra")
+            LBExtraMessage(key: "Extra key", value: "Extra value")
         ]
 
         for level in LBLogLevel.allCases {

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `log` method supports additional parameters for more detailed logs.
 #### Logging with extra messages:
 ```swift
 let extraMessages: [LBExtraMessage] = [
-    LBExtraMessage(title: "Title extra", message: "Message extra")
+    LBExtraMessage(key: "Extra key", value: "Extra value")
 ]
 LogBird.log("My Log",
     extraMessages: extraMessages)

--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -90,13 +90,13 @@ public struct LBError: Codable, Hashable, Sendable {
 
 public struct LBExtraMessage: Codable, Identifiable, Sendable {
     public let id: UUID
-    public let title: String
-    public let message: String
+    public let key: String
+    public let value: String
 
-    public init(id: UUID = UUID(), title: String, message: String) {
+    public init(id: UUID = UUID(), key: String, value: String) {
         self.id = id
-        self.title = title
-        self.message = message
+        self.key = key
+        self.value = value
     }
 }
 
@@ -104,12 +104,12 @@ extension LBExtraMessage: Hashable {
     /// Equality and hashing are content-based; `id` only gives each instance a
     /// unique identity for list rendering.
     public static func == (lhs: LBExtraMessage, rhs: LBExtraMessage) -> Bool {
-        lhs.title == rhs.title && lhs.message == rhs.message
+        lhs.key == rhs.key && lhs.value == rhs.value
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(title)
-        hasher.combine(message)
+        hasher.combine(key)
+        hasher.combine(value)
     }
 }
 

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -288,7 +288,7 @@ final class LBManager: @unchecked Sendable {
         // Extra Messages
         if let extraMessages = log.extraMessages {
             for extraMessage in extraMessages {
-                let message: String = "\(extraMessage.title):\n\(spacing)\(extraMessage.message)\n"
+                let message: String = "\(extraMessage.key):\n\(spacing)\(extraMessage.value)\n"
                 logMessage = "\(logMessage)\(message)"
             }
         }

--- a/Sources/LogBird/LogView/LBLogRowView.swift
+++ b/Sources/LogBird/LogView/LBLogRowView.swift
@@ -79,9 +79,9 @@ private extension LBLogRowView {
 
     @ViewBuilder
     func ExtraMessages(_ extraMessages: [LBExtraMessage]) -> some View {
-        ForEach(extraMessages) { value in
-            LogSection(title: value.title) {
-                Text(value.message)
+        ForEach(extraMessages) { extraMessage in
+            LogSection(title: extraMessage.key) {
+                Text(extraMessage.value)
             }
         }
     }

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -78,7 +78,7 @@ final class LogsViewModel: ObservableObject {
         }
 
         if let extraMessages = log.extraMessages,
-           extraMessages.contains(where: { $0.title.localizedCaseInsensitiveContains(query) || $0.message.localizedCaseInsensitiveContains(query) }) {
+           extraMessages.contains(where: { $0.key.localizedCaseInsensitiveContains(query) || $0.value.localizedCaseInsensitiveContains(query) }) {
             return true
         }
 

--- a/Tests/LogBirdTests/LBLogTests.swift
+++ b/Tests/LogBirdTests/LBLogTests.swift
@@ -89,8 +89,8 @@ final class LBLogTests: XCTestCase {
     }
 
     func testLBExtraMessageHasUniqueIdentityWithContentEquality() {
-        let first = LBExtraMessage(title: "title", message: "message")
-        let second = LBExtraMessage(title: "title", message: "message")
+        let first = LBExtraMessage(key: "key", value: "value")
+        let second = LBExtraMessage(key: "key", value: "value")
 
         XCTAssertEqual(first, second)
         XCTAssertNotEqual(first.id, second.id)


### PR DESCRIPTION
## What

Renames the `LBExtraMessage` properties `title` and `message` to `key` and `value`, including the memberwise initializer labels.

## Why

The pair read as a headline plus a body, which clashed with `LBLog.message` — a different field with a different meaning. `key`/`value` describes what the pair actually is: a short label and its associated text, matching how it is rendered, printed and searched.

This is a breaking API change and also changes the synthesized `Codable` keys of `LBExtraMessage`; it targets the next major release.

## Changes

- `LBExtraMessage`: properties, initializer labels, `Equatable`/`Hashable`
- Console output, search matching and log row rendering updated to the new names
- Example app, package tests and README snippet updated

## Testing

- `swift build` and `swift test` pass locally (62 tests)