### PR TITLE
Harden redaction, add nested metadata and zero-retention mode, improve logs export and search

### DIFF
--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -42,14 +42,16 @@ final class LBManager: @unchecked Sendable {
     private var storedSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
 
     /// The maximum number of entries kept in memory. Once the limit is reached,
-    /// the oldest entries are discarded. Values below 1 are treated as 1.
+    /// the oldest entries are discarded. A value of 0 disables retention: the
+    /// history stays empty while published events keep flowing. Negative values
+    /// are treated as 0.
     var maxLogs: Int {
         get {
             dispatchQueue.sync { storedMaxLogs }
         }
         set {
             dispatchQueue.sync {
-                self.storedMaxLogs = max(1, newValue)
+                self.storedMaxLogs = max(0, newValue)
                 self.trimLogs()
             }
         }
@@ -76,7 +78,7 @@ final class LBManager: @unchecked Sendable {
         let source = LBSource(subsystem: subsystem, category: category)
         self.logger = Logger(subsystem: source.subsystem, category: source.category)
         self.source = source
-        self.storedMaxLogs = max(1, maxLogs)
+        self.storedMaxLogs = max(0, maxLogs)
     }
 
     func setIdentifier(_ value: String?) {
@@ -158,7 +160,7 @@ final class LBManager: @unchecked Sendable {
         let log = LBLog(
             level: level,
             message: message,
-            extraMessages: extraMessages,
+            extraMessages: redactor.redact(extraMessages),
             additionalInfo: redactor.redact(additionalInfo),
             error: errorData,
             createdAt: Date().timeIntervalSince1970,

--- a/Sources/LogBird/LBRedactor.swift
+++ b/Sources/LogBird/LBRedactor.swift
@@ -9,9 +9,9 @@ import Foundation
 
 /// Replaces values under sensitive keys with a fixed placeholder.
 ///
-/// A key is sensitive when it contains any of the configured keys; matching is
-/// case-insensitive and applies to both sides, so `accessToken` and
-/// `AUTH_TOKEN` both match `token`.
+/// A key is sensitive when it contains any of the configured keys. Matching is
+/// case-insensitive and ignores underscores, hyphens and spaces, so
+/// `accessToken`, `access-token` and `ACCESS_TOKEN` all match `token`.
 struct LBRedactor: Sendable {
 
     static let placeholder = "<redacted>"
@@ -23,7 +23,7 @@ struct LBRedactor: Sendable {
 
     init(isEnabled: Bool, sensitiveKeys: [String]) {
         self.isEnabled = isEnabled
-        self.needles = sensitiveKeys.map { $0.lowercased() }
+        self.needles = sensitiveKeys.map(Self.normalize).filter { !$0.isEmpty }
     }
 
     func redact(_ info: [String: LBValue]?) -> [String: LBValue]? {
@@ -44,8 +44,22 @@ struct LBRedactor: Sendable {
         return redacted
     }
 
+    func redact(_ extraMessages: [LBExtraMessage]?) -> [LBExtraMessage]? {
+        guard let extraMessages, isEnabled else { return extraMessages }
+        return extraMessages.map { message in
+            guard isSensitive(message.key) else { return message }
+            return LBExtraMessage(id: message.id, key: message.key, value: Self.placeholder)
+        }
+    }
+
     private func isSensitive(_ key: String) -> Bool {
-        let key = key.lowercased()
+        let key = Self.normalize(key)
         return needles.contains { key.contains($0) }
+    }
+
+    /// Lowercases and strips separators, so written variants of the same key
+    /// (`api_key`, `x-api-key`, `API KEY`) compare equal.
+    private static func normalize(_ key: String) -> String {
+        key.lowercased().filter { $0 != "_" && $0 != "-" && !$0.isWhitespace }
     }
 }

--- a/Sources/LogBird/LBRedactor.swift
+++ b/Sources/LogBird/LBRedactor.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Replaces values under sensitive keys with a fixed placeholder.
 ///
 /// A key is sensitive when it contains any of the configured keys. Matching is
-/// case-insensitive and ignores underscores, hyphens and spaces, so
+/// case-insensitive and ignores underscores, hyphens and whitespace, so
 /// `accessToken`, `access-token` and `ACCESS_TOKEN` all match `token`.
 struct LBRedactor: Sendable {
 

--- a/Sources/LogBird/LBValue.swift
+++ b/Sources/LogBird/LBValue.swift
@@ -11,6 +11,7 @@ import Foundation
 ///
 /// Values keep their original type when encoded to JSON, so exported logs
 /// contain real numbers, booleans and strings instead of stringified output.
+/// Arrays and dictionaries nest values arbitrarily deep.
 ///
 /// Decoding is best-effort: JSON has no distinct URL type, so URLs decode as
 /// `.string`, and whole-number doubles (e.g. `12.0`, encoded as `12`) decode
@@ -22,6 +23,8 @@ public enum LBValue: Sendable {
     case double(Double)
     case bool(Bool)
     case url(URL)
+    indirect case array([LBValue])
+    indirect case dictionary([String: LBValue])
 }
 
 extension LBValue: Codable {
@@ -35,6 +38,10 @@ extension LBValue: Codable {
             self = .double(double)
         } else if let string = try? container.decode(String.self) {
             self = .string(string)
+        } else if let array = try? container.decode([LBValue].self) {
+            self = .array(array)
+        } else if let dictionary = try? container.decode([String: LBValue].self) {
+            self = .dictionary(dictionary)
         } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported additional info value")
         }
@@ -48,6 +55,8 @@ extension LBValue: Codable {
         case .double(let double): try container.encode(double)
         case .bool(let bool): try container.encode(bool)
         case .url(let url): try container.encode(url.absoluteString)
+        case .array(let array): try container.encode(array)
+        case .dictionary(let dictionary): try container.encode(dictionary)
         }
     }
 }
@@ -62,6 +71,10 @@ extension LBValue: CustomStringConvertible {
         case .double(let double): return String(double)
         case .bool(let bool): return String(bool)
         case .url(let url): return url.absoluteString
+        case .array(let array): return "[\(array.map(\.description).joined(separator: ", "))]"
+        case .dictionary(let dictionary):
+            let pairs = dictionary.keys.sorted().map { "\($0): \(dictionary[$0]!)" }
+            return "{\(pairs.joined(separator: ", "))}"
         }
     }
 }

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -69,7 +69,7 @@ extension LogBird {
 
     /// The keys considered sensitive when redacting. A key is sensitive when it
     /// contains any of these values; matching is case-insensitive and ignores
-    /// underscores, hyphens and spaces, so `accessToken` and `ACCESS-TOKEN`
+    /// underscores, hyphens and whitespace, so `accessToken` and `ACCESS-TOKEN`
     /// match `token`.
     ///
     /// Setting this property replaces the default keys; append to
@@ -145,7 +145,7 @@ extension LogBird {
 
     /// The keys considered sensitive when redacting. A key is sensitive when it
     /// contains any of these values; matching is case-insensitive and ignores
-    /// underscores, hyphens and spaces, so `accessToken` and `ACCESS-TOKEN`
+    /// underscores, hyphens and whitespace, so `accessToken` and `ACCESS-TOKEN`
     /// match `token`.
     ///
     /// Setting this property replaces the default keys; append to

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -41,7 +41,8 @@ extension LogBird {
         shared.logs
     }
 
-    /// The maximum number of entries kept in memory by `shared`.
+    /// The maximum number of entries kept in memory by `shared`. A value of 0
+    /// disables the in-memory history while events keep publishing.
     static public var maxLogs: Int {
         get { shared.maxLogs }
         set { shared.maxLogs = newValue }
@@ -53,22 +54,23 @@ extension LogBird {
     /// The string that replaces a redacted value.
     static public let redactionPlaceholder: String = LBRedactor.placeholder
 
-    /// Whether values under sensitive keys in `additionalInfo` and
-    /// `error.userInfo` are replaced by the redaction placeholder before a log
-    /// is stored. Default: `true`.
+    /// Whether values under sensitive keys in `additionalInfo`, `extraMessages`
+    /// and `error.userInfo` are replaced by the redaction placeholder before a
+    /// log is stored. Default: `true`.
     ///
     /// A redacted value is always stored as a string, regardless of its
-    /// original type. Free-text fields (`message`, `extraMessages`, and an
-    /// error's `localizedDescription`) are not scanned; mark sensitive values
-    /// at the call site with `LBLogMessage` instead.
+    /// original type. `message` and an error's `localizedDescription` are not
+    /// scanned; mark sensitive values at the call site with `LBLogMessage`
+    /// instead.
     static public var redactSensitiveFields: Bool {
         get { shared.redactSensitiveFields }
         set { shared.redactSensitiveFields = newValue }
     }
 
     /// The keys considered sensitive when redacting. A key is sensitive when it
-    /// contains any of these values; matching is case-insensitive, so
-    /// `accessToken` matches `token`.
+    /// contains any of these values; matching is case-insensitive and ignores
+    /// underscores, hyphens and spaces, so `accessToken` and `ACCESS-TOKEN`
+    /// match `token`.
     ///
     /// Setting this property replaces the default keys; append to
     /// `defaultSensitiveKeys` to extend them.
@@ -120,29 +122,31 @@ extension LogBird {
     }
 
     /// The maximum number of entries kept in memory. Once the limit is reached,
-    /// the oldest entries are discarded. Lowering the value trims the existing
-    /// history immediately and cannot be undone.
+    /// the oldest entries are discarded. A value of 0 disables the in-memory
+    /// history while events keep publishing. Lowering the value trims the
+    /// existing history immediately and cannot be undone.
     public var maxLogs: Int {
         get { manager.maxLogs }
         set { manager.maxLogs = newValue }
     }
 
-    /// Whether values under sensitive keys in `additionalInfo` and
-    /// `error.userInfo` are replaced by the redaction placeholder before a log
-    /// is stored. Default: `true`.
+    /// Whether values under sensitive keys in `additionalInfo`, `extraMessages`
+    /// and `error.userInfo` are replaced by the redaction placeholder before a
+    /// log is stored. Default: `true`.
     ///
     /// A redacted value is always stored as a string, regardless of its
-    /// original type. Free-text fields (`message`, `extraMessages`, and an
-    /// error's `localizedDescription`) are not scanned; mark sensitive values
-    /// at the call site with `LBLogMessage` instead.
+    /// original type. `message` and an error's `localizedDescription` are not
+    /// scanned; mark sensitive values at the call site with `LBLogMessage`
+    /// instead.
     public var redactSensitiveFields: Bool {
         get { manager.redactSensitiveFields }
         set { manager.redactSensitiveFields = newValue }
     }
 
     /// The keys considered sensitive when redacting. A key is sensitive when it
-    /// contains any of these values; matching is case-insensitive, so
-    /// `accessToken` matches `token`.
+    /// contains any of these values; matching is case-insensitive and ignores
+    /// underscores, hyphens and spaces, so `accessToken` and `ACCESS-TOKEN`
+    /// match `token`.
     ///
     /// Setting this property replaces the default keys; append to
     /// `LogBird.defaultSensitiveKeys` to extend them.

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -16,30 +16,35 @@ import UniformTypeIdentifiers
 
 enum LBLogExport {
 
-    static func fileName(for format: LBExportFormat) -> String {
-        "logbird-logs.\(format.fileExtension)"
+    /// A readable, sortable name such as `logbird-logs-20260729-143052.json`.
+    static func fileName(for format: LBExportFormat, date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "logbird-logs-\(formatter.string(from: date)).\(format.fileExtension)"
     }
 
-    static func writeTemporaryFile(data: Data, format: LBExportFormat) -> URL? {
+    static func writeTemporaryFile(data: Data, format: LBExportFormat) throws -> URL {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("logbird-logs-\(UUID().uuidString).\(format.fileExtension)")
-        do {
-            try data.write(to: url, options: .atomic)
-            return url
-        } catch {
-            return nil
-        }
+            .appendingPathComponent(fileName(for: format))
+        try data.write(to: url, options: .atomic)
+        return url
     }
 
     #if os(macOS)
     @MainActor
-    static func presentSavePanel(data: Data, format: LBExportFormat) {
+    static func presentSavePanel(data: Data, format: LBExportFormat, onError: @escaping (Error) -> Void) {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [contentType(for: format)]
         panel.nameFieldStringValue = fileName(for: format)
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
-            try? data.write(to: url, options: .atomic)
+            do {
+                try data.write(to: url, options: .atomic)
+            } catch {
+                onError(error)
+            }
         }
     }
 

--- a/Sources/LogBird/LogView/LBLogExport.swift
+++ b/Sources/LogBird/LogView/LBLogExport.swift
@@ -18,18 +18,29 @@ enum LBLogExport {
 
     /// A readable, sortable name such as `logbird-logs-20260729-143052.json`.
     static func fileName(for format: LBExportFormat, date: Date = Date()) -> String {
+        "\(timestampBase(for: date)).\(format.fileExtension)"
+    }
+
+    static func writeTemporaryFile(data: Data, format: LBExportFormat) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+        let base = timestampBase(for: Date())
+        var name = "\(base).\(format.fileExtension)"
+        var copy = 2
+        while FileManager.default.fileExists(atPath: directory.appendingPathComponent(name).path) {
+            name = "\(base)-\(copy).\(format.fileExtension)"
+            copy += 1
+        }
+        let url = directory.appendingPathComponent(name)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private static func timestampBase(for date: Date) -> String {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyyMMdd-HHmmss"
-        return "logbird-logs-\(formatter.string(from: date)).\(format.fileExtension)"
-    }
-
-    static func writeTemporaryFile(data: Data, format: LBExportFormat) throws -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(fileName(for: format))
-        try data.write(to: url, options: .atomic)
-        return url
+        return "logbird-logs-\(formatter.string(from: date))"
     }
 
     #if os(macOS)

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -110,7 +110,9 @@ public struct LBLogsView: View {
     /// The export covers what the list currently shows; the title says so when
     /// a search query or level filter narrows the visible entries.
     private var exportMenuTitle: String {
-        viewModel.isFiltering ? "Export \(viewModel.filteredLogs.count) Filtered Logs" : "Export Logs"
+        guard viewModel.isFiltering else { return "Export Logs" }
+        let count = viewModel.filteredLogs.count
+        return count == 1 ? "Export 1 Filtered Log" : "Export \(count) Filtered Logs"
     }
 
     private func exportLogs(format: LBExportFormat) {

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -12,6 +12,8 @@ public struct LBLogsView: View {
 
     @StateObject private var viewModel: LogsViewModel
 
+    @State private var exportError: String?
+
     #if os(iOS)
     @State private var exportFile: ExportFile?
     #endif
@@ -54,6 +56,18 @@ public struct LBLogsView: View {
             LBActivityView(activityItems: [file.url])
         }
         #endif
+        .alert("Export Failed", isPresented: exportErrorPresented, presenting: exportError) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { error in
+            Text(error)
+        }
+    }
+
+    private var exportErrorPresented: Binding<Bool> {
+        Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )
     }
 
     @ToolbarContentBuilder
@@ -77,7 +91,7 @@ public struct LBLogsView: View {
                         }
                     }
                 } label: {
-                    Label("Export Logs", systemImage: "square.and.arrow.up")
+                    Label(exportMenuTitle, systemImage: "square.and.arrow.up")
                 }
 
                 Button(role: .destructive) {
@@ -93,15 +107,25 @@ public struct LBLogsView: View {
         }
     }
 
+    /// The export covers what the list currently shows; the title says so when
+    /// a search query or level filter narrows the visible entries.
+    private var exportMenuTitle: String {
+        viewModel.isFiltering ? "Export \(viewModel.filteredLogs.count) Filtered Logs" : "Export Logs"
+    }
+
     private func exportLogs(format: LBExportFormat) {
-        guard let data = viewModel.exportData(format: format) else { return }
-        #if os(iOS)
-        if let url = LBLogExport.writeTemporaryFile(data: data, format: format) {
-            exportFile = ExportFile(url: url)
+        do {
+            let data = try viewModel.exportData(format: format)
+            #if os(iOS)
+            exportFile = ExportFile(url: try LBLogExport.writeTemporaryFile(data: data, format: format))
+            #elseif os(macOS)
+            LBLogExport.presentSavePanel(data: data, format: format) { error in
+                exportError = error.localizedDescription
+            }
+            #endif
+        } catch {
+            exportError = error.localizedDescription
         }
-        #elseif os(macOS)
-        LBLogExport.presentSavePanel(data: data, format: format)
-        #endif
     }
 }
 

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -61,9 +61,18 @@ final class LogsViewModel: ObservableObject {
     func handle(_ event: LBLogEvent) {
         switch event {
         case .recorded(let log):
+            let maxLogs = logBird.maxLogs
+            guard maxLogs > 0 else {
+                // Retention is disabled; the view mirrors the empty history.
+                if !logs.isEmpty {
+                    logs = []
+                    logIDs = []
+                }
+                return
+            }
             guard logIDs.insert(log.id).inserted else { return }
             logs.insert(log, at: 0)
-            let overflow = logs.count - logBird.maxLogs
+            let overflow = logs.count - maxLogs
             if overflow > 0 {
                 logIDs.subtract(logs.suffix(overflow).map(\.id))
                 logs.removeLast(overflow)
@@ -100,7 +109,7 @@ final class LogsViewModel: ObservableObject {
         if let error = log.error,
            error.localizedDescription.localizedCaseInsensitiveContains(query)
             || error.domain.localizedCaseInsensitiveContains(query)
-            || String(error.code).contains(query)
+            || String(error.code).localizedCaseInsensitiveContains(query)
             || (error.userInfo?.contains(where: { $0.key.localizedCaseInsensitiveContains(query) || $0.value.localizedCaseInsensitiveContains(query) }) ?? false) {
             return true
         }

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -17,11 +17,13 @@ final class LogsViewModel: ObservableObject {
 
     private let logBird: LogBird
     private var logsCancellable: AnyCancellable?
+    private var logIDs: Set<String> = []
 
     init(logBird: LogBird = LogBird.shared) {
         self.logBird = logBird
         subscribeToLogs()
         logs = logBird.logs
+        logIDs = Set(logs.map(\.id))
     }
 
     var filteredLogs: [LBLog] {
@@ -30,13 +32,19 @@ final class LogsViewModel: ObservableObject {
         }
     }
 
+    /// Whether the visible logs are narrowed by a search query or a level filter.
+    var isFiltering: Bool {
+        levelFilter != nil || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     func clearLogs() {
         logBird.clearLogs()
         logs = []
+        logIDs = []
     }
 
-    func exportData(format: LBExportFormat = .json) -> Data? {
-        try? LBLogExporter.data(for: filteredLogs, format: format, identifier: logBird.currentIdentifier)
+    func exportData(format: LBExportFormat = .json) throws -> Data {
+        try LBLogExporter.data(for: filteredLogs, format: format, identifier: logBird.currentIdentifier)
     }
 
     private func subscribeToLogs() {
@@ -53,14 +61,16 @@ final class LogsViewModel: ObservableObject {
     func handle(_ event: LBLogEvent) {
         switch event {
         case .recorded(let log):
-            guard !logs.contains(where: { $0.id == log.id }) else { return }
+            guard logIDs.insert(log.id).inserted else { return }
             logs.insert(log, at: 0)
             let overflow = logs.count - logBird.maxLogs
             if overflow > 0 {
+                logIDs.subtract(logs.suffix(overflow).map(\.id))
                 logs.removeLast(overflow)
             }
         case .cleared:
             logs = []
+            logIDs = []
         }
     }
 
@@ -82,7 +92,20 @@ final class LogsViewModel: ObservableObject {
             return true
         }
 
-        if let error = log.error, error.localizedDescription.localizedCaseInsensitiveContains(query) {
+        if let additionalInfo = log.additionalInfo,
+           additionalInfo.contains(where: { $0.key.localizedCaseInsensitiveContains(query) || $0.value.description.localizedCaseInsensitiveContains(query) }) {
+            return true
+        }
+
+        if let error = log.error,
+           error.localizedDescription.localizedCaseInsensitiveContains(query)
+            || error.domain.localizedCaseInsensitiveContains(query)
+            || String(error.code).contains(query) {
+            return true
+        }
+
+        if log.source.subsystem.localizedCaseInsensitiveContains(query)
+            || log.source.category.localizedCaseInsensitiveContains(query) {
             return true
         }
 

--- a/Sources/LogBird/LogView/LogsViewModel.swift
+++ b/Sources/LogBird/LogView/LogsViewModel.swift
@@ -100,7 +100,8 @@ final class LogsViewModel: ObservableObject {
         if let error = log.error,
            error.localizedDescription.localizedCaseInsensitiveContains(query)
             || error.domain.localizedCaseInsensitiveContains(query)
-            || String(error.code).contains(query) {
+            || String(error.code).contains(query)
+            || (error.userInfo?.contains(where: { $0.key.localizedCaseInsensitiveContains(query) || $0.value.localizedCaseInsensitiveContains(query) }) ?? false) {
             return true
         }
 

--- a/Tests/LogBirdTests/LBLogExportTests.swift
+++ b/Tests/LogBirdTests/LBLogExportTests.swift
@@ -27,4 +27,20 @@ final class LBLogExportTests: XCTestCase {
         XCTAssertTrue(url.lastPathComponent.hasPrefix("logbird-logs-"))
         XCTAssertTrue(url.lastPathComponent.hasSuffix(".log"))
     }
+
+    func testWriteTemporaryFileKeepsExistingFiles() throws {
+        let first = Data("first".utf8)
+        let second = Data("second".utf8)
+
+        let firstURL = try LBLogExport.writeTemporaryFile(data: first, format: .json)
+        let secondURL = try LBLogExport.writeTemporaryFile(data: second, format: .json)
+        defer {
+            try? FileManager.default.removeItem(at: firstURL)
+            try? FileManager.default.removeItem(at: secondURL)
+        }
+
+        XCTAssertNotEqual(firstURL, secondURL)
+        XCTAssertEqual(try Data(contentsOf: firstURL), first)
+        XCTAssertEqual(try Data(contentsOf: secondURL), second)
+    }
 }

--- a/Tests/LogBirdTests/LBLogExportTests.swift
+++ b/Tests/LogBirdTests/LBLogExportTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LogBird
+
+final class LBLogExportTests: XCTestCase {
+
+    func testFileNameUsesReadableTimestamp() {
+        let name = LBLogExport.fileName(for: .json, date: Date(timeIntervalSince1970: 1_700_000_000))
+
+        XCTAssertNotNil(
+            name.range(of: #"^logbird-logs-\d{8}-\d{6}\.json$"#, options: .regularExpression),
+            "Unexpected file name: \(name)"
+        )
+    }
+
+    func testFileNameUsesFormatExtension() {
+        XCTAssertTrue(LBLogExport.fileName(for: .jsonLines).hasSuffix(".jsonl"))
+        XCTAssertTrue(LBLogExport.fileName(for: .plainText).hasSuffix(".log"))
+    }
+
+    func testWriteTemporaryFileWritesData() throws {
+        let data = Data("exported logs".utf8)
+
+        let url = try LBLogExport.writeTemporaryFile(data: data, format: .plainText)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertEqual(try Data(contentsOf: url), data)
+        XCTAssertTrue(url.lastPathComponent.hasPrefix("logbird-logs-"))
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(".log"))
+    }
+}

--- a/Tests/LogBirdTests/LBLogTests.swift
+++ b/Tests/LogBirdTests/LBLogTests.swift
@@ -63,9 +63,29 @@ final class LBLogTests: XCTestCase {
         XCTAssertEqual(decoded["site"], .string("https://example.com"))
     }
 
+    func testLBValueNestedValuesCodableRoundTrip() throws {
+        let values: [String: LBValue] = [
+            "tags": .array([.string("swift"), .int(6), .bool(true)]),
+            "context": .dictionary([
+                "screen": .string("checkout"),
+                "attempt": .int(2),
+                "ids": .array([.int(1), .int(2)])
+            ])
+        ]
+
+        let data = try JSONEncoder().encode(values)
+        let decoded = try JSONDecoder().decode([String: LBValue].self, from: data)
+
+        XCTAssertEqual(decoded, values)
+    }
+
+    func testLBValueNestedDescription() {
+        XCTAssertEqual(LBValue.array([.int(1), .string("two")]).description, "[1, two]")
+        XCTAssertEqual(LBValue.dictionary(["b": .int(2), "a": .int(1)]).description, "{a: 1, b: 2}")
+    }
+
     func testLBValueDecodeFailsForUnsupportedPayloads() {
-        XCTAssertThrowsError(try JSONDecoder().decode(LBValue.self, from: Data("[1, 2]".utf8)))
-        XCTAssertThrowsError(try JSONDecoder().decode(LBValue.self, from: Data(#"{"a": 1}"#.utf8)))
+        XCTAssertThrowsError(try JSONDecoder().decode(LBValue.self, from: Data("null".utf8)))
     }
 
     func testLBValueExpressibleByLiterals() {

--- a/Tests/LogBirdTests/LBManagerTests.swift
+++ b/Tests/LogBirdTests/LBManagerTests.swift
@@ -30,18 +30,48 @@ final class LBManagerTests: XCTestCase {
         XCTAssertEqual(logBird.logs.last?.message, "log-40")
     }
 
-    func testMaxLogsBelowOneIsClamped() {
-        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-clamp", maxLogs: 0)
-        XCTAssertEqual(logBird.maxLogs, 1)
-
-        logBird.maxLogs = -5
-        XCTAssertEqual(logBird.maxLogs, 1)
+    func testMaxLogsZeroDisablesRetention() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-zero", maxLogs: 0)
+        XCTAssertEqual(logBird.maxLogs, 0)
 
         logBird.log("first")
         logBird.log("second")
 
-        XCTAssertEqual(logBird.logs.count, 1)
-        XCTAssertEqual(logBird.logs.first?.message, "second")
+        XCTAssertTrue(logBird.logs.isEmpty)
+    }
+
+    func testMaxLogsZeroStillPublishesEvents() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-zero-events", maxLogs: 0)
+
+        let expectation = expectation(description: "entries published without retention")
+        var published: [LBLog] = []
+        let cancellable = logBird.logsPublisher.sink { event in
+            guard case .recorded(let log) = event else { return }
+            published.append(log)
+            if published.count == 2 {
+                expectation.fulfill()
+            }
+        }
+
+        logBird.log("first")
+        logBird.log("second")
+
+        wait(for: [expectation], timeout: 5)
+        cancellable.cancel()
+        XCTAssertEqual(published.map(\.message), ["first", "second"])
+        XCTAssertTrue(logBird.logs.isEmpty)
+    }
+
+    func testNegativeMaxLogsIsClampedToZero() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "maxlogs-negative")
+
+        logBird.maxLogs = -5
+
+        XCTAssertEqual(logBird.maxLogs, 0)
+
+        logBird.log("first")
+
+        XCTAssertTrue(logBird.logs.isEmpty)
     }
 
     func testLogWithoutMessage() {

--- a/Tests/LogBirdTests/LBRedactionTests.swift
+++ b/Tests/LogBirdTests/LBRedactionTests.swift
@@ -96,6 +96,48 @@ final class LBRedactionTests: XCTestCase {
         XCTAssertEqual(info?["token"], .string("abc123"))
     }
 
+    func testSensitiveKeyMatchingIgnoresSeparators() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-separators")
+
+        logBird.log("separators", additionalInfo: [
+            "api_key": .string("a"),
+            "x-api-key": .string("b"),
+            "API-KEY": .string("c"),
+            "auth token": .string("d")
+        ])
+
+        let info = logBird.logs.first?.additionalInfo
+        XCTAssertEqual(info?["api_key"], .string("<redacted>"))
+        XCTAssertEqual(info?["x-api-key"], .string("<redacted>"))
+        XCTAssertEqual(info?["API-KEY"], .string("<redacted>"))
+        XCTAssertEqual(info?["auth token"], .string("<redacted>"))
+    }
+
+    func testExtraMessageValuesAreRedactedByKey() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-extra-messages")
+
+        logBird.log("request", extraMessages: [
+            LBExtraMessage(key: "Authorization", value: "Bearer abc123"),
+            LBExtraMessage(key: "endpoint", value: "/login")
+        ])
+
+        let extraMessages = logBird.logs.first?.extraMessages
+        XCTAssertEqual(extraMessages?.first(where: { $0.key == "Authorization" })?.value, "<redacted>")
+        XCTAssertEqual(extraMessages?.first(where: { $0.key == "endpoint" })?.value, "/login")
+    }
+
+    func testExtraMessageRedactionKeepsEntryIdentity() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-extra-identity")
+        let original = LBExtraMessage(key: "session_token", value: "abc123")
+
+        logBird.log("request", extraMessages: [original])
+
+        let redacted = logBird.logs.first?.extraMessages?.first
+        XCTAssertEqual(redacted?.id, original.id)
+        XCTAssertEqual(redacted?.key, "session_token")
+        XCTAssertEqual(redacted?.value, "<redacted>")
+    }
+
     func testPlainTextExportDoesNotLeakSensitiveValues() throws {
         let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-plaintext")
 

--- a/Tests/LogBirdTests/LBRedactionTests.swift
+++ b/Tests/LogBirdTests/LBRedactionTests.swift
@@ -138,6 +138,15 @@ final class LBRedactionTests: XCTestCase {
         XCTAssertEqual(redacted?.value, "<redacted>")
     }
 
+    func testExtraMessagesUntouchedWhenRedactionDisabled() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-extra-disabled")
+        logBird.redactSensitiveFields = false
+
+        logBird.log("request", extraMessages: [LBExtraMessage(key: "Authorization", value: "Bearer abc123")])
+
+        XCTAssertEqual(logBird.logs.first?.extraMessages?.first?.value, "Bearer abc123")
+    }
+
     func testPlainTextExportDoesNotLeakSensitiveValues() throws {
         let logBird = LogBird(subsystem: "com.logbird.tests", category: "redaction-plaintext")
 

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -4,10 +4,12 @@ import XCTest
 @MainActor
 final class LogsViewModelTests: XCTestCase {
 
-    private func makeLog(message: String?, level: LBLogLevel, file: String = "LogBird/LBManager.swift") -> LBLog {
+    private func makeLog(message: String?, level: LBLogLevel, file: String = "LogBird/LBManager.swift", additionalInfo: [String: LBValue]? = nil, error: LBError? = nil) -> LBLog {
         LBLog(
             level: level,
             message: message,
+            additionalInfo: additionalInfo,
+            error: error,
             createdAt: Date().timeIntervalSince1970,
             location: LBLocation(file: file, function: "log(_:)", line: 42),
             source: LBSource(subsystem: "com.logbird.tests", category: "viewmodel")
@@ -109,17 +111,68 @@ final class LogsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.filteredLogs.first?.message, "Network request finished")
     }
 
+    func testSearchMatchesAdditionalInfoKeysAndValues() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "search-info"))
+        viewModel.logs = [
+            makeLog(message: "one", level: .info, additionalInfo: ["endpoint": .string("/checkout")]),
+            makeLog(message: "two", level: .info)
+        ]
+
+        viewModel.searchText = "checkout"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+
+        viewModel.searchText = "endpoint"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+    }
+
+    func testSearchMatchesErrorDomainAndCode() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "search-error"))
+        let error = LBError(domain: "com.test.networking", code: 401, type: "NSError", localizedDescription: "Unauthorized")
+        viewModel.logs = [
+            makeLog(message: "one", level: .error, error: error),
+            makeLog(message: "two", level: .info)
+        ]
+
+        viewModel.searchText = "networking"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+
+        viewModel.searchText = "401"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+    }
+
+    func testSearchMatchesSource() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "search-source"))
+        viewModel.logs = [
+            makeLog(message: "one", level: .info)
+        ]
+
+        viewModel.searchText = "logbird.tests"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+
+        viewModel.searchText = "viewmodel"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+    }
+
     func testExportDataEncodesFilteredLogs() throws {
         let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "export"))
         viewModel.logs = [
             makeLog(message: "exported", level: .warning)
         ]
 
-        let data = try XCTUnwrap(viewModel.exportData())
+        let data = try viewModel.exportData()
         let decoded = try JSONDecoder().decode([LBLog].self, from: data)
 
         XCTAssertEqual(decoded.count, 1)
         XCTAssertEqual(decoded.first?.message, "exported")
+    }
+
+    func testExportDataThrowsOnNonFiniteValues() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "export-error"))
+        viewModel.logs = [
+            makeLog(message: "nan", level: .info, additionalInfo: ["ratio": .double(.nan)])
+        ]
+
+        XCTAssertThrowsError(try viewModel.exportData())
     }
 
     func testLocationFileNameStripsModulePath() {

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -72,6 +72,28 @@ final class LogsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.logs.map(\.message), ["one", "three"])
     }
 
+    func testRecordedEventsAreIgnoredWhenRetentionIsDisabled() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "vm-zero-retention", maxLogs: 0)
+        let viewModel = LogsViewModel(logBird: logBird)
+
+        viewModel.handle(.recorded(makeLog(message: "dropped", level: .info)))
+
+        XCTAssertTrue(viewModel.logs.isEmpty)
+    }
+
+    func testDisablingRetentionAtRuntimeEmptiesViewModelOnNextEvent() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "vm-runtime-zero", maxLogs: 10)
+        let viewModel = LogsViewModel(logBird: logBird)
+
+        viewModel.handle(.recorded(makeLog(message: "kept", level: .info)))
+        XCTAssertEqual(viewModel.logs.count, 1)
+
+        logBird.maxLogs = 0
+        viewModel.handle(.recorded(makeLog(message: "dropped", level: .info)))
+
+        XCTAssertTrue(viewModel.logs.isEmpty)
+    }
+
     func testIsFilteringReflectsQueryAndLevelFilter() {
         let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "is-filtering"))
 

--- a/Tests/LogBirdTests/LogsViewModelTests.swift
+++ b/Tests/LogBirdTests/LogsViewModelTests.swift
@@ -59,6 +59,35 @@ final class LogsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.logs.map(\.message), ["three", "two"])
     }
 
+    func testTrimmedLogCanBeRedelivered() {
+        let logBird = LogBird(subsystem: "com.logbird.tests", category: "trim-redeliver", maxLogs: 2)
+        let viewModel = LogsViewModel(logBird: logBird)
+        let trimmed = makeLog(message: "one", level: .info)
+
+        viewModel.handle(.recorded(trimmed))
+        viewModel.handle(.recorded(makeLog(message: "two", level: .info)))
+        viewModel.handle(.recorded(makeLog(message: "three", level: .info)))
+        viewModel.handle(.recorded(trimmed))
+
+        XCTAssertEqual(viewModel.logs.map(\.message), ["one", "three"])
+    }
+
+    func testIsFilteringReflectsQueryAndLevelFilter() {
+        let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "is-filtering"))
+
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.searchText = "   "
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.searchText = "network"
+        XCTAssertTrue(viewModel.isFiltering)
+
+        viewModel.searchText = ""
+        viewModel.levelFilter = .error
+        XCTAssertTrue(viewModel.isFiltering)
+    }
+
     func testClearedEventEmptiesViewModel() {
         let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "cleared-event"))
         viewModel.handle(.recorded(makeLog(message: "to-be-cleared", level: .info)))
@@ -127,7 +156,7 @@ final class LogsViewModelTests: XCTestCase {
 
     func testSearchMatchesErrorDomainAndCode() {
         let viewModel = LogsViewModel(logBird: LogBird(subsystem: "com.logbird.tests", category: "search-error"))
-        let error = LBError(domain: "com.test.networking", code: 401, type: "NSError", localizedDescription: "Unauthorized")
+        let error = LBError(domain: "com.test.networking", code: 401, type: "NSError", localizedDescription: "Unauthorized", userInfo: ["endpoint": "/login"])
         viewModel.logs = [
             makeLog(message: "one", level: .error, error: error),
             makeLog(message: "two", level: .info)
@@ -137,6 +166,9 @@ final class LogsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
 
         viewModel.searchText = "401"
+        XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
+
+        viewModel.searchText = "endpoint"
         XCTAssertEqual(viewModel.filteredLogs.map(\.message), ["one"])
     }
 


### PR DESCRIPTION
## Summary

- Sensitive-key matching now ignores underscores, hyphens and spaces, so written variants like `api_key`, `x-api-key` or `API-KEY` are redacted the same as `apiKey`. Extra message values are redacted when their key is sensitive.
- `LBValue` gains indirect `array` and `dictionary` cases for nested metadata, with Codable round-trip and readable text descriptions.
- `maxLogs = 0` disables in-memory retention (OSLog-only mode) while published events keep flowing; negative values clamp to 0. The default is unchanged.
- Export failures from the logs view surface in an alert instead of failing silently, exported files use readable timestamped names (`logbird-logs-<yyyyMMdd-HHmmss>.<ext>`), and the export menu states when it covers the filtered logs only.
- Recorded logs are deduped through an id set instead of a linear scan, and search now also matches additional info keys/values, error domain and code, and the source subsystem/category.

## Behavior notes

- Keys such as `api_key` or `x-api-key` that previously stayed unredacted are now stored as `<redacted>`.
- Values of `extraMessages` entries whose key is sensitive are now stored as `<redacted>`.
- `LBValue` has two new cases, so exhaustive switches over the enum in consumer code need updating.
- `maxLogs = 0` no longer clamps to 1; it empties and disables the history. Only affects callers that set 0 explicitly.

## Verification

- `swift build` and `swift test` (76 tests) pass on macOS.
- Strict concurrency build (`-strict-concurrency=complete`) passes.
- iOS build passes.