### PR TITLE
Add tvOS and watchOS platform support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,3 +15,17 @@ jobs:
         run: swift build
       - name: Test
         run: swift test
+
+  build-platforms:
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        destination:
+          - 'generic/platform=iOS'
+          - 'generic/platform=tvOS'
+          - 'generic/platform=watchOS'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build for ${{ matrix.destination }}
+        run: xcodebuild -scheme LogBird -destination '${{ matrix.destination }}' build CODE_SIGNING_ALLOWED=NO

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "LogBird",
-    platforms: [.iOS(.v15), .macOS(.v12)],
+    platforms: [.iOS(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v8)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Release](https://img.shields.io/github/v/release/javiermanzo/LogBird?style=flat-square)
 [![CI](https://img.shields.io/github/actions/workflow/status/javiermanzo/LogBird/swift.yml?style=flat-square)](https://github.com/javiermanzo/LogBird/actions/workflows/swift.yml)
 [![Swift](https://img.shields.io/badge/Swift-5.9_6.0-orange?style=flat-square)](https://swift.org/)
-[![Platforms](https://img.shields.io/badge/Platforms-macOS_iOS-yellowgreen?style=flat-square)](https://github.com/javiermanzo/LogBird#requirements) 
+[![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS-yellowgreen?style=flat-square)](https://github.com/javiermanzo/LogBird#requirements) 
 [![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square)](https://swiftpackageindex.com/javiermanzo/LogBird)
 
 LogBird is a powerful yet simple logging library for Swift, designed to provide flexible and efficient console logging.
@@ -44,6 +44,8 @@ LogBird is a powerful yet simple logging library for Swift, designed to provide 
 - Swift 5.9 or 6.0 toolchain (Swift 5 and 6 language modes are both supported)
 - iOS 15.0+
 - macOS 12.0+
+- tvOS 15.0+
+- watchOS 8.0+
 
 ## Installation
 LogBird is distributed as a Swift Package. Add it to your project using [Swift Package Manager](https://swift.org/package-manager/).

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -25,7 +25,7 @@ public struct LBLogsView: View {
     }
 
     public var body: some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             NavigationStack {
                 content
             }

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -46,9 +46,11 @@ public struct LBLogsView: View {
         .accessibilityHint("Displays the recorded log entries")
         .searchable(text: $viewModel.searchText, prompt: "Search logs")
         .navigationTitle("Logs")
+        #if os(iOS) || os(macOS)
         .toolbar {
             toolbarContent
         }
+        #endif
         #if os(iOS)
         .sheet(item: $exportFile) { file in
             LBActivityView(activityItems: [file.url])
@@ -56,6 +58,7 @@ public struct LBLogsView: View {
         #endif
     }
 
+    #if os(iOS) || os(macOS)
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
@@ -103,6 +106,7 @@ public struct LBLogsView: View {
         LBLogExport.presentSavePanel(data: data, format: format)
         #endif
     }
+    #endif
 }
 
 private extension LBExportFormat {


### PR DESCRIPTION
Adds tvOS and watchOS as supported platforms alongside iOS and macOS.

- Declares `.tvOS(.v15)` and `.watchOS(.v8)` deployment targets in `Package.swift`.
- Extends the `NavigationStack` availability check to cover tvOS 16 and watchOS 9, so the view falls back to `NavigationView` on the lower deployment targets.
- Export stays a no-op on tvOS and watchOS: the export UI is guarded by `#if os(iOS)` / `#if os(macOS)`, and those platforms have no share sheet / save panel equivalent.
- Adds a CI job that builds the package for iOS, tvOS, and watchOS to keep cross-platform support green.