### PR TITLE
docs: document public API and organize by access level

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ LogBird.logsPublisher
     .store(in: &subscribers)
 ```
 
-The recorded history is always available synchronously via `LogBird.logs` (newest first).
+The recorded history is always available synchronously via `LogBird.logs` (oldest first, in recording order).
 
 ### SwiftUI View
 Use `LBLogsView` to visualize logs in your app. You can optionally provide a custom `LogBird` instance; by default, it uses the static instance:
@@ -165,7 +165,7 @@ customLogger.clearLogs()
 
 ## How It Works
 
-- **Storage**: every log is kept in an in-memory history (newest first) capped at `maxLogs` entries. The history is readable synchronously via `logs`; call `clearLogs()` to empty it.
+- **Storage**: every log is kept in an in-memory history (oldest first, in recording order) capped at `maxLogs` entries. The history is readable synchronously via `logs`; call `clearLogs()` to empty it.
 - **Console output**: under the hood, each entry is also forwarded to `OSLog` (`os.Logger`), so logs are visible in Console.app and via `log stream` under your subsystem and category (pass `--debug` to `log stream` to include debug-level entries).
 - **Combine**: `logsPublisher` emits an `LBLogEvent` for each new entry (`recorded`) and every `clearLogs()` call (`cleared`); earlier events are not replayed to new subscribers. Read `logs` for a synchronous snapshot of the recorded history.
 - **SwiftUI**: `LBLogsView` observes `logsPublisher` through an internal `ObservableObject` view model and re-renders on each new entry.

--- a/Sources/LogBird/LBLog.swift
+++ b/Sources/LogBird/LBLog.swift
@@ -12,16 +12,27 @@ import Foundation
 /// Equality and hashing include `id`, so two entries are equal only when they
 /// represent the same recorded log.
 public struct LBLog: Codable, Identifiable, Hashable, Sendable {
+    /// Stable unique identifier for the entry.
     public let id: String
+    /// Severity of the entry.
     public let level: LBLogLevel
+    /// Free-text message, if any.
     public let message: String?
+    /// Labeled strings shown as separate sections, if any.
     public let extraMessages: [LBExtraMessage]?
+    /// Typed metadata keyed by name, if any.
     public let additionalInfo: [String: LBValue]?
+    /// Captured error details, if any.
     public let error: LBError?
+    /// Creation time, as seconds since the Unix epoch.
     public let createdAt: Double
+    /// Where the entry was recorded in source.
     public let location: LBLocation
+    /// OSLog subsystem and category the entry was recorded under.
     public let source: LBSource
 
+    /// Creates an entry. `id` defaults to a fresh UUID string; the other
+    /// parameters map one-to-one to the stored properties.
     init(
         id: String = UUID().uuidString,
         level: LBLogLevel,
@@ -45,8 +56,11 @@ public struct LBLog: Codable, Identifiable, Hashable, Sendable {
     }
 }
 
+/// The OSLog subsystem and category an entry was recorded under.
 public struct LBSource: Codable, Hashable, Sendable {
+    /// Reverse-DNS identifier used by OSLog (e.g. `com.example.myapp`).
     public let subsystem: String
+    /// OSLog category used to scope entries in Console.app.
     public let category: String
 
     init(subsystem: String, category: String) {
@@ -55,9 +69,13 @@ public struct LBSource: Codable, Hashable, Sendable {
     }
 }
 
+/// The source location where an entry was recorded.
 public struct LBLocation: Codable, Hashable, Sendable {
+    /// `#fileID` value at the call site (module/file path).
     public let file: String
+    /// `#function` value at the call site.
     public let function: String
+    /// `#line` value at the call site.
     public let line: Int
 
     init(file: String, function: String, line: Int) {
@@ -72,11 +90,18 @@ public struct LBLocation: Codable, Hashable, Sendable {
     }
 }
 
+/// Captured details of an `Error` recorded with a log entry.
 public struct LBError: Codable, Hashable, Sendable {
+    /// `NSError.domain` of the captured error.
     public let domain: String
+    /// `NSError.code` of the captured error.
     public let code: Int
+    /// Concrete Swift type of the captured error.
     public let type: String
+    /// `localizedDescription` of the captured error.
     public let localizedDescription: String
+    /// Stringified `userInfo`, with decoding/encoding context merged in for
+    /// `DecodingError` / `EncodingError`. `nil` when empty.
     public let userInfo: [String: String]?
 
     init(domain: String, code: Int, type: String, localizedDescription: String, userInfo: [String: String]? = nil) {
@@ -88,11 +113,16 @@ public struct LBError: Codable, Hashable, Sendable {
     }
 }
 
+/// A labeled string shown as its own section within a log entry.
 public struct LBExtraMessage: Codable, Identifiable, Sendable {
+    /// Stable unique identifier for list rendering.
     public let id: UUID
+    /// Section label.
     public let key: String
+    /// Section contents.
     public let value: String
 
+    /// Creates an extra message. `id` defaults to a fresh UUID.
     public init(id: UUID = UUID(), key: String, value: String) {
         self.id = id
         self.key = key
@@ -100,6 +130,7 @@ public struct LBExtraMessage: Codable, Identifiable, Sendable {
     }
 }
 
+// MARK: Hashable
 extension LBExtraMessage: Hashable {
     /// Equality and hashing are content-based; `id` only gives each instance a
     /// unique identity for list rendering.
@@ -113,16 +144,22 @@ extension LBExtraMessage: Hashable {
     }
 }
 
+// MARK: Encoding
 public extension LBLog {
-    private static let prettyJSONEncoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        return encoder
-    }()
 
     /// Returns a deterministic, pretty-printed JSON representation of the log.
     func prettyJSON() throws -> String {
         let data = try Self.prettyJSONEncoder.encode(self)
         return String(decoding: data, as: UTF8.self)
     }
+}
+
+// MARK: Private
+private extension LBLog {
+
+    static let prettyJSONEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
 }

--- a/Sources/LogBird/LBLogLevel.swift
+++ b/Sources/LogBird/LBLogLevel.swift
@@ -9,20 +9,16 @@ import Foundation
 import OSLog
 import SwiftUI
 
+/// Severity of a log entry. Cases are ordered from least to most severe.
 public enum LBLogLevel: String, Codable, CaseIterable, Sendable {
     case debug, info, warning, error, critical
-    
-    public var osLogType: OSLogType {
-        switch self {
-        case .debug: return .debug
-        case .info: return .info
-        case .warning: return .default
-        case .error: return .error
-        case .critical: return .fault
-        }
-    }
-    
-    public var emoji: String {
+}
+
+// MARK: Public
+public extension LBLogLevel {
+
+    /// Emoji prefix used in the OSLog header and the SwiftUI row.
+    var emoji: String {
         switch self {
         case .debug: return "🐞"
         case .info: return "ℹ️"
@@ -32,7 +28,8 @@ public enum LBLogLevel: String, Codable, CaseIterable, Sendable {
         }
     }
 
-    public var color: Color {
+    /// Background tint used by `LBLogRowView` for the level.
+    var color: Color {
         switch self {
         case .debug: return .secondary
         case .info: return .blue
@@ -42,7 +39,8 @@ public enum LBLogLevel: String, Codable, CaseIterable, Sendable {
         }
     }
 
-    public var symbolName: String {
+    /// SF Symbol name used by `LBLogsView` for the level filter.
+    var symbolName: String {
         switch self {
         case .debug: return "ant"
         case .info: return "info.circle"
@@ -53,8 +51,25 @@ public enum LBLogLevel: String, Codable, CaseIterable, Sendable {
     }
 }
 
+// MARK: CustomStringConvertible
 extension LBLogLevel: CustomStringConvertible {
+
     public var description: String {
         rawValue
+    }
+}
+
+// MARK: Internal
+extension LBLogLevel {
+
+    /// Matching `OSLogType` used when forwarding the entry to OSLog.
+    var osLogType: OSLogType {
+        switch self {
+        case .debug: return .debug
+        case .info: return .info
+        case .warning: return .default
+        case .error: return .error
+        case .critical: return .fault
+        }
     }
 }

--- a/Sources/LogBird/LBLogMessage.swift
+++ b/Sources/LogBird/LBLogMessage.swift
@@ -38,12 +38,21 @@ public struct LBLogMessage: ExpressibleByStringInterpolation, Hashable, Sendable
     }
 }
 
+// MARK: CustomStringConvertible
 extension LBLogMessage: CustomStringConvertible {
+
     public var description: String { value }
 }
 
-extension LBLogMessage {
-    public struct StringInterpolation: StringInterpolationProtocol {
+// MARK: StringInterpolation
+public extension LBLogMessage {
+
+    /// String interpolation backing `LBLogMessage`.
+    ///
+    /// Interpolations are public by default; the `appendInterpolation(_:privacy:)`
+    /// overload swaps a `.private` value for the redaction placeholder while
+    /// the message is built.
+    struct StringInterpolation: StringInterpolationProtocol {
         var output: String
 
         public init(literalCapacity: Int, interpolationCount: Int) {
@@ -55,10 +64,17 @@ extension LBLogMessage {
             output.append(literal)
         }
 
+        /// Appends a public interpolation, rendered with `String(describing:)`.
         public mutating func appendInterpolation<T>(_ value: T) {
             output.append(String(describing: value))
         }
 
+        /// Appends an interpolation whose visibility is controlled by `privacy`.
+        /// A `.private` value is replaced by the redaction placeholder.
+        ///
+        /// - Parameters:
+        ///   - value: `T` — value to interpolate.
+        ///   - privacy: `LBPrivacy` — `.public` to render, `.private` to redact.
         public mutating func appendInterpolation<T>(_ value: T, privacy: LBPrivacy) {
             switch privacy {
             case .public:

--- a/Sources/LogBird/LBManager.swift
+++ b/Sources/LogBird/LBManager.swift
@@ -82,12 +82,27 @@ final class LBManager: @unchecked Sendable {
         self.storedMaxLogs = max(0, maxLogs)
     }
 
+    /// Sets an optional identifier prepended to each OSLog line.
+    ///
+    /// - Parameter value: `String?` — identifier to prepend, or `nil` to clear.
     func setIdentifier(_ value: String?) {
         dispatchQueue.sync {
             self.identifier = value
         }
     }
 
+    /// Builds a log, forwards it to OSLog and records it (subject to `maxLogs`).
+    /// Subscribers receive a `.recorded` event on the publish queue.
+    ///
+    /// - Parameters:
+    ///   - message: `String?` — free-text message.
+    ///   - extraMessages: `[LBExtraMessage]?` — labeled strings.
+    ///   - additionalInfo: `[String: LBValue]?` — typed metadata.
+    ///   - error: `Error?` — error to capture.
+    ///   - level: `LBLogLevel` — severity.
+    ///   - file: `String` — source file.
+    ///   - function: `String` — source function.
+    ///   - line: `Int` — source line.
     func log(_ message: String? = nil,
              extraMessages: [LBExtraMessage]? = nil,
              additionalInfo: [String: LBValue]? = nil,
@@ -123,6 +138,7 @@ final class LBManager: @unchecked Sendable {
         }
     }
 
+    /// Empties the recorded history. Subscribers receive a `.cleared` event.
     func clearLogs() {
         dispatchQueue.sync {
             self.logs = []
@@ -130,11 +146,22 @@ final class LBManager: @unchecked Sendable {
         }
     }
 
+    /// Encodes the recorded history.
+    ///
+    /// - Parameter format: `LBExportFormat` — encoding to use.
+    /// - Throws: `EncodingError` if a log value cannot be encoded.
+    /// - Returns: `Data` containing the encoded history.
     func exportLogs(format: LBExportFormat) throws -> Data {
         let (logs, identifier) = dispatchQueue.sync { (self.logs, self.identifier) }
         return try LBLogExporter.data(for: logs, format: format, identifier: identifier)
     }
 
+    /// Encodes the recorded history and writes it to `url` atomically.
+    ///
+    /// - Parameters:
+    ///   - url: `URL` — destination file URL.
+    ///   - format: `LBExportFormat` — encoding to use.
+    /// - Throws: `EncodingError` if a value cannot be encoded, or the file-system error if writing fails.
     func writeLogs(to url: URL, format: LBExportFormat) throws {
         try exportLogs(format: format).write(to: url, options: .atomic)
     }
@@ -156,7 +183,7 @@ final class LBManager: @unchecked Sendable {
                               line: Int,
                               redactor: LBRedactor) -> LBLog {
 
-        let errorData: LBError? = errorToLBError(error, redactor: redactor) ?? nil
+        let errorData: LBError? = errorToLBError(error, redactor: redactor)
 
         let log = LBLog(
             level: level,
@@ -266,6 +293,12 @@ final class LBManager: @unchecked Sendable {
         }
     }
 
+    /// Builds the human-readable block forwarded to OSLog.
+    ///
+    /// - Parameters:
+    ///   - log: `LBLog` — entry to format.
+    ///   - identifier: `String?` — optional identifier prepended to the header.
+    /// - Returns: `String` with the formatted block.
     static func formattedMessage(for log: LBLog, identifier: String?) -> String {
         var logMessage: String = ""
         let spacing: String = "    "

--- a/Sources/LogBird/LBValue.swift
+++ b/Sources/LogBird/LBValue.swift
@@ -18,16 +18,25 @@ import Foundation
 /// as `.int`. Encoding a non-finite double (NaN or infinity) throws, as with
 /// any `JSONEncoder`.
 public enum LBValue: Sendable {
+    /// A string value.
     case string(String)
+    /// An integer value.
     case int(Int)
+    /// A floating-point value.
     case double(Double)
+    /// A Boolean value.
     case bool(Bool)
+    /// A URL value, encoded as its absolute string.
     case url(URL)
+    /// An array of nested values.
     indirect case array([LBValue])
+    /// A dictionary of nested values keyed by name.
     indirect case dictionary([String: LBValue])
 }
 
+// MARK: Codable
 extension LBValue: Codable {
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let bool = try? container.decode(Bool.self) {
@@ -61,9 +70,12 @@ extension LBValue: Codable {
     }
 }
 
+// MARK: Hashable
 extension LBValue: Hashable {}
 
+// MARK: CustomStringConvertible
 extension LBValue: CustomStringConvertible {
+
     public var description: String {
         switch self {
         case .string(let string): return string
@@ -79,25 +91,33 @@ extension LBValue: CustomStringConvertible {
     }
 }
 
+// MARK: ExpressibleByStringLiteral
 extension LBValue: ExpressibleByStringLiteral {
+
     public init(stringLiteral value: String) {
         self = .string(value)
     }
 }
 
+// MARK: ExpressibleByIntegerLiteral
 extension LBValue: ExpressibleByIntegerLiteral {
+
     public init(integerLiteral value: Int) {
         self = .int(value)
     }
 }
 
+// MARK: ExpressibleByFloatLiteral
 extension LBValue: ExpressibleByFloatLiteral {
+
     public init(floatLiteral value: Double) {
         self = .double(value)
     }
 }
 
+// MARK: ExpressibleByBooleanLiteral
 extension LBValue: ExpressibleByBooleanLiteral {
+
     public init(booleanLiteral value: Bool) {
         self = .bool(value)
     }

--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -8,51 +8,62 @@
 import Foundation
 import Combine
 
+/// A logger that keeps a bounded in-memory history, mirrors entries to OSLog
+/// and publishes history events through Combine.
+///
+/// Use the static API (`LogBird.log(_:)`, `LogBird.logs`, ...) for a shared
+/// instance, or create one with `init(subsystem:category:maxLogs:)` for an
+/// isolated subsystem/category pair and history. Instances are thread-safe.
 public class LogBird: @unchecked Sendable {
 
     private let manager: LBManager
 
+    /// Creates a logger that records under the given `subsystem` and `category`.
+    ///
+    /// - Parameters:
+    ///   - subsystem: Reverse-DNS identifier used by OSLog (e.g.
+    ///     `com.example.myapp`).
+    ///   - category: OSLog category used to scope entries in Console.app.
+    ///   - maxLogs: Maximum number of entries kept in memory. Older entries are
+    ///     discarded first. `0` disables the in-memory history while published
+    ///     events keep flowing. Defaults to `1000`.
     public init(subsystem: String, category: String, maxLogs: Int = 1000) {
         manager = LBManager(subsystem: subsystem, category: category, maxLogs: maxLogs)
     }
 }
 
-// MARK: Public Static methods
-extension LogBird {
-    /// Uses the host bundle identifier as subsystem, or a stable default where
-    /// the bundle provides none (e.g. tests or command-line tools).
-    static public let shared = LogBird(subsystem: resolvedSubsystem(bundleIdentifier: Bundle.main.bundleIdentifier), category: "general")
+// MARK: Public Static
+public extension LogBird {
 
-    /// Returns the bundle identifier to use as subsystem, or a stable default
-    /// when the host bundle has none.
-    static func resolvedSubsystem(bundleIdentifier: String?) -> String {
-        bundleIdentifier ?? "com.logbird.default"
-    }
+    /// A shared logger that uses the host bundle identifier as subsystem and
+    /// `general` as category, or a stable default where the bundle provides
+    /// none (e.g. tests or command-line tools).
+    static let shared = LogBird(subsystem: resolvedSubsystem(bundleIdentifier: Bundle.main.bundleIdentifier), category: "general")
 
     /// Publishes history events as they happen: `recorded` for each new entry
     /// and `cleared` when the history is emptied. Earlier events are not
     /// replayed to new subscribers; use `logs` for the recorded history.
-    static public var logsPublisher: AnyPublisher<LBLogEvent, Never> {
+    static var logsPublisher: AnyPublisher<LBLogEvent, Never> {
         shared.logsPublisher
     }
 
     /// The recorded history of `shared`, in recording order (oldest first).
-    static public var logs: [LBLog] {
+    static var logs: [LBLog] {
         shared.logs
     }
 
     /// The maximum number of entries kept in memory by `shared`. A value of 0
     /// disables the in-memory history while events keep publishing.
-    static public var maxLogs: Int {
+    static var maxLogs: Int {
         get { shared.maxLogs }
         set { shared.maxLogs = newValue }
     }
 
     /// Keys matched by default when redacting sensitive fields.
-    static public let defaultSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
+    static let defaultSensitiveKeys: [String] = LBRedactor.defaultSensitiveKeys
 
     /// The string that replaces a redacted value.
-    static public let redactionPlaceholder: String = LBRedactor.placeholder
+    static let redactionPlaceholder: String = LBRedactor.placeholder
 
     /// Whether values under sensitive keys in `additionalInfo`, `extraMessages`
     /// and `error.userInfo` are replaced by the redaction placeholder before a
@@ -62,7 +73,7 @@ extension LogBird {
     /// original type. `message` and an error's `localizedDescription` are not
     /// scanned; mark sensitive values at the call site with `LBLogMessage`
     /// instead.
-    static public var redactSensitiveFields: Bool {
+    static var redactSensitiveFields: Bool {
         get { shared.redactSensitiveFields }
         set { shared.redactSensitiveFields = newValue }
     }
@@ -74,50 +85,78 @@ extension LogBird {
     ///
     /// Setting this property replaces the default keys; append to
     /// `defaultSensitiveKeys` to extend them.
-    static public var sensitiveKeys: [String] {
+    static var sensitiveKeys: [String] {
         get { shared.sensitiveKeys }
         set { shared.sensitiveKeys = newValue }
     }
 
-    static public func setIdentifier(_ identifier: String?) {
+    /// Sets an optional identifier prepended to each OSLog line for the shared
+    /// instance, such as a session or user id.
+    ///
+    /// - Parameter identifier: `String?` — identifier to prepend, or `nil` to clear.
+    static func setIdentifier(_ identifier: String?) {
         shared.setIdentifier(identifier)
     }
 
-    static public func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    /// Records a log entry on the shared instance.
+    ///
+    /// - Parameters:
+    ///   - message: `String?` — free-text message. Use `LBLogMessage` to redact sensitive content.
+    ///   - extraMessages: `[LBExtraMessage]?` — labeled strings shown as separate sections.
+    ///   - additionalInfo: `[String: LBValue]?` — typed metadata keyed by name.
+    ///   - error: `Error?` — error to capture (includes `DecodingError`/`EncodingError` context).
+    ///   - level: `LBLogLevel` — severity. Defaults to `.debug`.
+    ///   - file: `String` — source file. Defaults to `#fileID`.
+    ///   - function: `String` — source function. Defaults to `#function`.
+    ///   - line: `Int` — source line. Defaults to `#line`.
+    static func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         shared.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
-    static public func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    /// Records a log entry built from a privacy-aware `LBLogMessage`.
+    /// Parameters other than `message` match the `String?` overload.
+    static func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         shared.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
     /// Empties the recorded history. Subscribers receive a `cleared` event.
-    static public func clearLogs() {
+    static func clearLogs() {
         shared.clearLogs()
     }
 
-    static public func exportLogs(format: LBExportFormat = .json) throws -> Data {
+    /// Exports the recorded history of the shared instance.
+    ///
+    /// - Parameter format: `LBExportFormat` — encoding to use. Defaults to `.json`.
+    /// - Throws: `EncodingError` if a log value cannot be encoded (e.g. non-finite double).
+    /// - Returns: `Data` containing the encoded history.
+    static func exportLogs(format: LBExportFormat = .json) throws -> Data {
         try shared.exportLogs(format: format)
     }
 
-    static public func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
+    /// Writes the recorded history of the shared instance to `url`.
+    ///
+    /// - Parameters:
+    ///   - url: `URL` — destination file URL.
+    ///   - format: `LBExportFormat` — encoding to use. Defaults to `.json`.
+    /// - Throws: `EncodingError` if a value cannot be encoded, or the file-system error if writing fails.
+    static func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
         try shared.writeLogs(to: url, format: format)
     }
 }
 
-// MARK: Public Methods
-extension LogBird {
+// MARK: Public
+public extension LogBird {
 
     /// Publishes history events as they happen: `recorded` for each new entry
     /// and `cleared` when the history is emptied. Earlier events are not
     /// replayed to new subscribers; use `logs` for the recorded history.
-    public var logsPublisher: AnyPublisher<LBLogEvent, Never> {
+    var logsPublisher: AnyPublisher<LBLogEvent, Never> {
         manager.logsPublisher
     }
 
     /// The recorded history, in recording order (oldest first). The number of
     /// entries is capped at `maxLogs`.
-    public var logs: [LBLog] {
+    var logs: [LBLog] {
         manager.logsSnapshot
     }
 
@@ -125,7 +164,7 @@ extension LogBird {
     /// the oldest entries are discarded. A value of 0 disables the in-memory
     /// history while events keep publishing. Lowering the value trims the
     /// existing history immediately and cannot be undone.
-    public var maxLogs: Int {
+    var maxLogs: Int {
         get { manager.maxLogs }
         set { manager.maxLogs = newValue }
     }
@@ -138,7 +177,7 @@ extension LogBird {
     /// original type. `message` and an error's `localizedDescription` are not
     /// scanned; mark sensitive values at the call site with `LBLogMessage`
     /// instead.
-    public var redactSensitiveFields: Bool {
+    var redactSensitiveFields: Bool {
         get { manager.redactSensitiveFields }
         set { manager.redactSensitiveFields = newValue }
     }
@@ -150,42 +189,76 @@ extension LogBird {
     ///
     /// Setting this property replaces the default keys; append to
     /// `LogBird.defaultSensitiveKeys` to extend them.
-    public var sensitiveKeys: [String] {
+    var sensitiveKeys: [String] {
         get { manager.sensitiveKeys }
         set { manager.sensitiveKeys = newValue }
     }
 
-    public func setIdentifier(_ value: String?) {
+    /// Sets an optional identifier prepended to each OSLog line for this
+    /// instance, such as a session or user id.
+    ///
+    /// - Parameter value: `String?` — identifier to prepend, or `nil` to clear.
+    func setIdentifier(_ value: String?) {
         manager.setIdentifier(value)
     }
 
-    public func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    /// Records a log entry on this instance.
+    ///
+    /// - Parameters:
+    ///   - message: `String?` — free-text message. Use `LBLogMessage` to redact sensitive content.
+    ///   - extraMessages: `[LBExtraMessage]?` — labeled strings shown as separate sections.
+    ///   - additionalInfo: `[String: LBValue]?` — typed metadata keyed by name.
+    ///   - error: `Error?` — error to capture (includes `DecodingError`/`EncodingError` context).
+    ///   - level: `LBLogLevel` — severity. Defaults to `.debug`.
+    ///   - file: `String` — source file. Defaults to `#fileID`.
+    ///   - function: `String` — source function. Defaults to `#function`.
+    ///   - line: `Int` — source line. Defaults to `#line`.
+    func log(_ message: String? = nil, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         manager.log(message, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
-    public func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
+    /// Records a log entry built from a privacy-aware `LBLogMessage`.
+    /// Parameters other than `message` match the `String?` overload.
+    func log(_ message: LBLogMessage, extraMessages: [LBExtraMessage]? = nil, additionalInfo: [String: LBValue]? = nil, error: Error? = nil, level: LBLogLevel = .debug, file: String = #fileID, function: String = #function, line: Int = #line) {
         manager.log(message.value, extraMessages: extraMessages, additionalInfo: additionalInfo, error: error, level: level, file: file, function: function, line: line)
     }
 
     /// Empties the recorded history. Subscribers receive a `cleared` event.
-    public func clearLogs() {
+    func clearLogs() {
         manager.clearLogs()
     }
 
-    var currentIdentifier: String? {
-        manager.currentIdentifier
-    }
-
-    /// Exports the recorded history in the given format.
+    /// Exports the recorded history.
     ///
-    /// - Throws: an `EncodingError` if a log value cannot be encoded
-    ///   (e.g. a non-finite double in `additionalInfo`).
-    public func exportLogs(format: LBExportFormat = .json) throws -> Data {
+    /// - Parameter format: `LBExportFormat` — encoding to use. Defaults to `.json`.
+    /// - Throws: `EncodingError` if a log value cannot be encoded (e.g. non-finite double).
+    /// - Returns: `Data` containing the encoded history.
+    func exportLogs(format: LBExportFormat = .json) throws -> Data {
         try manager.exportLogs(format: format)
     }
 
-    /// Writes the recorded history to a file in the given format.
-    public func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
+    /// Writes the recorded history to `url`.
+    ///
+    /// - Parameters:
+    ///   - url: `URL` — destination file URL.
+    ///   - format: `LBExportFormat` — encoding to use. Defaults to `.json`.
+    /// - Throws: `EncodingError` if a value cannot be encoded, or the file-system error if writing fails.
+    func writeLogs(to url: URL, format: LBExportFormat = .json) throws {
         try manager.writeLogs(to: url, format: format)
+    }
+}
+
+// MARK: Internal
+extension LogBird {
+
+    /// Returns the bundle identifier to use as subsystem, or a stable default
+    /// when the host bundle has none.
+    static func resolvedSubsystem(bundleIdentifier: String?) -> String {
+        bundleIdentifier ?? "com.logbird.default"
+    }
+
+    /// The identifier currently prepended to each OSLog line, if any.
+    var currentIdentifier: String? {
+        manager.currentIdentifier
     }
 }

--- a/Sources/LogBird/LogView/LBLogsView.swift
+++ b/Sources/LogBird/LogView/LBLogsView.swift
@@ -7,6 +7,12 @@
 
 import SwiftUI
 
+/// SwiftUI view that lists the recorded history, with search, level filter,
+/// export and clear actions.
+///
+/// The view observes `logsPublisher` through an internal view model, so it
+/// updates as new entries are recorded. By default it backs onto `LogBird.shared`;
+/// pass a custom instance to `init(logBird:)` to scope it differently.
 @MainActor
 public struct LBLogsView: View {
 


### PR DESCRIPTION
## Summary

Make the public API self-describing for AI tooling and IDEs by adding `///` doc comments across the surface, and clean up file organization.

## Changes

**Documentation (the main goal)**
- `LogBird` class + init + static and instance `log`/`setIdentifier`/`exportLogs`/`writeLogs`
- `LBLog`, `LBSource`, `LBLocation`, `LBError`, `LBExtraMessage` and their stored properties
- `LBLogLevel` enum + `emoji`/`color`/`symbolName`
- `LBValue` cases
- `LBLogMessage` + `StringInterpolation` + `appendInterpolation(_:privacy:)`
- `LBLogsView`
- Internal `LBManager` methods: `setIdentifier`, `log`, `exportLogs`, `writeLogs`, `formattedMessage`

Method docs include `- Parameters:` with type and a concise description.

**Organization**
- Each file grouped into `public extension` / `extension` (internal) / `private extension` blocks
- One extension per protocol conformance (`Codable`, `Hashable`, `CustomStringConvertible`, `ExpressibleBy*Literal`)
- Removed redundant access modifiers carried by the extension

**Visibility fix**
- Demoted `LBLogLevel.osLogType` to internal — OSLog mapping detail, not needed by consumers

**Other small fixes**
- README: corrected `logs` ordering from "newest first" to "oldest first" (matches `LogBird.logs` recording order)
- `LBManager`: dropped redundant `?? nil` on `errorToLBError` result

## Verification
- `swift build` clean
- `swift test` — 99/99 pass