### PR TITLE
feat(logging): infer subsystem and category defaults in LogBird init

### DIFF
--- a/Sources/LogBird/LogBird.swift
+++ b/Sources/LogBird/LogBird.swift
@@ -13,22 +13,49 @@ import Combine
 ///
 /// Use the static API (`LogBird.log(_:)`, `LogBird.logs`, ...) for a shared
 /// instance, or create one with `init(subsystem:category:maxLogs:)` for an
-/// isolated subsystem/category pair and history. Instances are thread-safe.
+/// isolated subsystem/category pair and history. Both `subsystem` and
+/// `category` default to sensible, caller-aware values, so `LogBird()` is
+/// usually enough. Instances are thread-safe.
 public class LogBird: @unchecked Sendable {
 
     private let manager: LBManager
 
     /// Creates a logger that records under the given `subsystem` and `category`.
     ///
+    /// Both default to caller-aware values so that `LogBird()` works out of the
+    /// box:
+    ///
+    /// - `subsystem` defaults to `Bundle.main.bundleIdentifier` (falling back
+    ///   to `"com.logbird.default"` where the host bundle provides none). This
+    ///   follows the OSLog convention of one subsystem per app.
+    /// - `category` defaults to the module name of the call site, derived from
+    ///   `fileID` (e.g. a call from `Network/Client.swift` uses `Network`, one
+    ///   from `MyApp/AppDelegate.swift` uses `MyApp`). This scopes entries in
+    ///   Console.app to whoever created the logger, instead of a generic label.
+    ///
+    /// Packages that need a stable, isolated subsystem regardless of host
+    /// (e.g. an SDK) should pass `subsystem` explicitly at a single,
+    /// package-internal call site.
+    ///
     /// - Parameters:
     ///   - subsystem: Reverse-DNS identifier used by OSLog (e.g.
-    ///     `com.example.myapp`).
+    ///     `com.example.myapp`). Defaults to the host bundle identifier.
     ///   - category: OSLog category used to scope entries in Console.app.
+    ///     Pass `nil` (the default) to infer the caller's module name from
+    ///     `fileID`, or a string to pin it.
+    ///   - fileID: `#fileID` at the call site, used only to infer `category`
+    ///     when it is `nil`. You should not need to pass this explicitly.
     ///   - maxLogs: Maximum number of entries kept in memory. Older entries are
     ///     discarded first. `0` disables the in-memory history while published
     ///     events keep flowing. Defaults to `1000`.
-    public init(subsystem: String, category: String, maxLogs: Int = 1000) {
-        manager = LBManager(subsystem: subsystem, category: category, maxLogs: maxLogs)
+    public init(
+        subsystem: String = resolvedSubsystem(bundleIdentifier: Bundle.main.bundleIdentifier),
+        category: String? = nil,
+        fileID: String = #fileID,
+        maxLogs: Int = 1000
+    ) {
+        let resolvedCategory = category ?? Self.defaultCategory(fileID: fileID)
+        manager = LBManager(subsystem: subsystem, category: resolvedCategory, maxLogs: maxLogs)
     }
 }
 
@@ -253,8 +280,20 @@ extension LogBird {
 
     /// Returns the bundle identifier to use as subsystem, or a stable default
     /// when the host bundle has none.
+    @usableFromInline
     static func resolvedSubsystem(bundleIdentifier: String?) -> String {
         bundleIdentifier ?? "com.logbird.default"
+    }
+
+    /// Derives a default OSLog category from a `#fileID` value by taking its
+    /// module component. `#fileID` has the form `Module/File.swift`, so the
+    /// result reflects whoever creates the logger instead of a generic label.
+    /// When the value has no module separator the whole string is returned.
+    static func defaultCategory(fileID: String) -> String {
+        if let slash = fileID.firstIndex(of: "/") {
+            return String(fileID[..<slash])
+        }
+        return fileID
     }
 
     /// The identifier currently prepended to each OSLog line, if any.

--- a/Tests/LogBirdTests/LogBirdTests.swift
+++ b/Tests/LogBirdTests/LogBirdTests.swift
@@ -153,6 +153,64 @@ final class LogBirdTests: XCTestCase {
         XCTAssertEqual(LogBird.resolvedSubsystem(bundleIdentifier: "com.example.app"), "com.example.app")
     }
 
+    /// `defaultCategory(fileID:)` returns the module component of `#fileID`,
+    /// so a package or app gets a category that reflects who owns the logger.
+    func testDefaultCategoryDerivesModuleFromFileID() {
+        XCTAssertEqual(LogBird.defaultCategory(fileID: "LogBird/LogBird.swift"), "LogBird")
+        XCTAssertEqual(LogBird.defaultCategory(fileID: "Network/Client.swift"), "Network")
+        XCTAssertEqual(LogBird.defaultCategory(fileID: "MyApp/AppDelegate.swift"), "MyApp")
+    }
+
+    /// When `#fileID` has no module separator, the whole value is returned as
+    /// the category rather than crashing or returning empty.
+    func testDefaultCategoryFallsBackToWholeValueWithoutSeparator() {
+        XCTAssertEqual(LogBird.defaultCategory(fileID: "AppDelegate.swift"), "AppDelegate.swift")
+        XCTAssertEqual(LogBird.defaultCategory(fileID: ""), "")
+    }
+
+    /// `LogBird()` uses the host bundle identifier as the subsystem default,
+    /// whatever the host bundle happens to be in the test runner.
+    func testInitDefaultsInferSubsystemFromMainBundle() {
+        let logBird = LogBird()
+        logBird.log("default-init-subsystem")
+
+        XCTAssertEqual(
+            logBird.logs.first?.source.subsystem,
+            LogBird.resolvedSubsystem(bundleIdentifier: Bundle.main.bundleIdentifier)
+        )
+    }
+
+    /// `LogBird()` infers the category from the caller's module. Called from
+    /// this file, `#fileID` is `LogBirdTests/LogBirdTests.swift`, so the
+    /// category is the test module's name.
+    func testInitDefaultsInferCategoryFromCallerModule() {
+        let logBird = LogBird()
+        logBird.log("default-init-category")
+
+        XCTAssertEqual(logBird.logs.first?.source.category, "LogBirdTests")
+    }
+
+    /// Explicit `subsystem`/`category` always win over the inferred defaults.
+    func testInitExplicitArgumentsOverrideDefaults() {
+        let logBird = LogBird(subsystem: "com.network.lib", category: "auth")
+        logBird.log("explicit-override")
+
+        let source = logBird.logs.first?.source
+        XCTAssertEqual(source?.subsystem, "com.network.lib")
+        XCTAssertEqual(source?.category, "auth")
+    }
+
+    /// Partial override is supported: passing only `category` keeps the
+    /// inferred subsystem default.
+    func testInitPartialOverrideKeepsInferredSubsystem() {
+        let logBird = LogBird(category: "payments")
+        logBird.log("partial-override")
+
+        let source = logBird.logs.first?.source
+        XCTAssertEqual(source?.subsystem, LogBird.resolvedSubsystem(bundleIdentifier: Bundle.main.bundleIdentifier))
+        XCTAssertEqual(source?.category, "payments")
+    }
+
     /// The static API forwards to `shared`: logging, history, configuration,
     /// publisher and export all operate on the same instance.
     func testStaticFacadeRoutesCallsToSharedInstance() throws {


### PR DESCRIPTION
## Summary

`LogBird()` now works with zero configuration, inferring both OSLog identifiers from caller-aware signals:

- **`subsystem`** defaults to `Bundle.main.bundleIdentifier` (falling back to `com.logbird.default`). This follows the OSLog convention of one subsystem per app and is the only value inferable portably.
- **`category`** defaults to the **caller's module name**, derived from `#fileID` (`Network/Client.swift` → `Network`, `MyApp/AppDelegate.swift` → `MyApp`). This replaces the previous hard-coded `general` label with something that reflects whoever creates the logger.

Explicit arguments always win, so existing call sites are unchanged (a `String` category is promoted to the new `String?`).

## Why `fileID` is a parameter

`#fileID` only resolves to the call site when it is a **bare** default-argument parameter. When wrapped in a helper call (`defaultCategory(fileID: #fileID)`), the whole default-argument expression is serialized into the module interface and `#fileID` gets baked in at LogBird's compile time (always `LogBird`). The init therefore takes a `fileID: String = #fileID` parameter and derives the category in its body — the same pattern already used for `file:` in `log(...)`.

## API changes

- `category` becomes `String?` (`nil` ⇒ infer from `fileID`). Source-compatible via optional promotion.
- New trailing `fileID: String = #fileID` parameter (callers don't pass it).
- `resolvedSubsystem` is now `@usableFromInline` (referenced from a serialized default argument); `defaultCategory` is internal (init-body only).

## Usage

```swift
// App — zero config
let logger = LogBird()
// subsystem = com.javier.myapp   category = MyApp

// Package that wants an isolated subsystem — declared once internally
public extension LogBird {
    static let network = LogBird(subsystem: \"com.network.lib\")
}
```

## Test plan

- [x] `swift test` — 105 tests pass, including 6 new ones covering `defaultCategory(fileID:)`, inferred subsystem/category from `LogBird()`, explicit override, and partial override.
- [x] Verified caller-site `#fileID` resolution (category is `LogBirdTests`, not `LogBird`).